### PR TITLE
Added QueryBuilder class for pagination and other purposes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceRoot}\\WordPressPCLTests\\bin\\Debug\\netcoreapp1.1\\WordPressPCLTests.dll",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "externalConsole": false,
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command.pickProcess}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "eslint.enable": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.1.0",
+    "command": "dotnet",
+    "isShellCommand": true,
+    "args": [],
+    "tasks": [
+        {
+            "taskName": "build",
+            "args": [
+                "${workspaceRoot}\\WordPressPCLTests\\WordPressPCLTests.csproj"
+            ],
+            "isBuildCommand": true,
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/WordPressPCL/Models/AuthMethod.cs
+++ b/WordPressPCL/Models/AuthMethod.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace WordPressPCL.Models
 {
     public enum AuthMethod

--- a/WordPressPCL/Models/CommentCreate.cs
+++ b/WordPressPCL/Models/CommentCreate.cs
@@ -1,7 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace WordPressPCL.Models
 {

--- a/WordPressPCL/Models/JWTUser.cs
+++ b/WordPressPCL/Models/JWTUser.cs
@@ -1,7 +1,5 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace WordPressPCL.Models
 {

--- a/WordPressPCL/Models/Links.cs
+++ b/WordPressPCL/Models/Links.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace WordPressPCL.Models
 {

--- a/WordPressPCL/Utility/Authentication.cs
+++ b/WordPressPCL/Utility/Authentication.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 
 namespace WordPressPCL.Utility
 {

--- a/WordPressPCL/Utility/QueryBuilder.cs
+++ b/WordPressPCL/Utility/QueryBuilder.cs
@@ -6,20 +6,20 @@ namespace WordPressPCL.Utility
 {
     public class QueryBuilder
     {
-        private string url { get; set; }
-        public int page { get; set; }
-        public int per_page { get; set; }
-        public int offset { get; set; }
-        public OrderBy orderBy { get; set; }
-        public bool embed { get; set; }
+        private string url;
+        public int Page { get; set; }
+        public int Per_Page { get; set; }
+        public int Offset { get; set; }
+        public WordPressPCL.Models.OrderBy OrderBy { get; set; }
+        public bool Embed { get; set; }
         public QueryBuilder(string url = null)
         {
             this.url = url;
-            this.page = 1;
-            this.per_page = 10;
-            this.offset = 0;
-            this.orderBy = OrderBy.date;
-            this.embed = false;
+            this.Page = 1;
+            this.Per_Page = 10;
+            this.Offset = 0;
+            this.OrderBy = OrderBy.date;
+            this.Embed = false;
         }
 
         internal QueryBuilder SetRootUrl(string _url) 
@@ -34,29 +34,29 @@ namespace WordPressPCL.Utility
             else
             {
                 StringBuilder sb = new StringBuilder(url);
-                if (page > 1)
+                if (Page > 1)
                 {
                     sb.Append(appendQuery(this.url, PAGE_QUERYSTRING));
-                    sb.Append(this.page);
+                    sb.Append(this.Page);
                 }
-                if (embed)
+                if (Embed)
                 {
                     sb.Append(appendQuery(this.url, EMBED_QUERYSTRING));
                 }
-                if (per_page != 10)
+                if (Per_Page != 10)
                 {
                     sb.Append(appendQuery(this.url, PER_PAGE_QUERYSTRING));
-                    sb.Append(this.per_page);
+                    sb.Append(this.Per_Page);
                 }
-                if (offset > 0)
+                if (Offset > 0)
                 {
                     sb.Append(appendQuery(this.url, OFFSET_QUERYSTRING));
-                    sb.Append(this.offset);
+                    sb.Append(this.Offset);
                 }
-                if (orderBy != OrderBy.date)
+                if (OrderBy != OrderBy.date)
                 {
                     sb.Append(appendQuery(this.url, ORDER_BY_QUERYSTRING));
-                    sb.Append(Convert.ToInt32(this.orderBy));
+                    sb.Append(Convert.ToInt32(this.OrderBy));
                 }
                 return sb.ToString();
             }

--- a/WordPressPCL/Utility/QueryBuilder.cs
+++ b/WordPressPCL/Utility/QueryBuilder.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Text;
+using WordPressPCL.Models;
+
+namespace WordPressPCL.Utility
+{
+    public class QueryBuilder
+    {
+        private string url { get; set; }
+        public int page { get; set; }
+        public int per_page { get; set; }
+        public int offset { get; set; }
+        public OrderBy orderBy { get; set; }
+        public bool embed { get; set; }
+        public QueryBuilder(string url = null)
+        {
+            this.url = url;
+            this.page = 1;
+            this.per_page = 10;
+            this.offset = 0;
+            this.orderBy = OrderBy.date;
+            this.embed = false;
+        }
+
+        internal QueryBuilder SetRootUrl(string _url) 
+        {
+            this.url = _url;
+            return this;
+        }
+
+        public override string ToString()
+        {
+            if (String.IsNullOrEmpty(this.url)) return string.Empty;
+            else
+            {
+                StringBuilder sb = new StringBuilder(url);
+                if (page > 1)
+                {
+                    sb.Append(appendQuery(this.url, PAGE_QUERYSTRING));
+                    sb.Append(this.page);
+                }
+                if (embed)
+                {
+                    sb.Append(appendQuery(this.url, EMBED_QUERYSTRING));
+                }
+                if (per_page != 10)
+                {
+                    sb.Append(appendQuery(this.url, PER_PAGE_QUERYSTRING));
+                    sb.Append(this.per_page);
+                }
+                if (offset > 0)
+                {
+                    sb.Append(appendQuery(this.url, OFFSET_QUERYSTRING));
+                    sb.Append(this.offset);
+                }
+                if (orderBy != OrderBy.date)
+                {
+                    sb.Append(appendQuery(this.url, ORDER_BY_QUERYSTRING));
+                    sb.Append(Convert.ToInt32(this.orderBy));
+                }
+                return sb.ToString();
+            }
+        }
+
+        private string appendQuery(string url, string queryString)
+        {
+            return (url.Contains(QUESTION_MARK) ? AMPERSAND : QUESTION_MARK) + queryString + EQUALS_SYMBOL;
+        }
+
+        #region constants
+        private const string PAGE_QUERYSTRING = "page";
+        private const string EMBED_QUERYSTRING = "_embed";        
+        private const string PER_PAGE_QUERYSTRING = "per_page";        
+        private const string OFFSET_QUERYSTRING = "offset";        
+        private const string ORDER_BY_QUERYSTRING = "orderby";
+        private const string QUESTION_MARK = "?";
+        private const string AMPERSAND = "&";
+        private const string EQUALS_SYMBOL = "=";
+        #endregion
+
+    }
+}

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -64,11 +64,25 @@ namespace WordPressPCL
             return await GetRequest<Post[]>($"{defaultPath}posts", embed).ConfigureAwait(false);
         }
 
+        public async Task<IList<Post>> ListPosts(QueryBuilder builder)
+        {
+            // default values 
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return await GetRequest<Post[]>(builder.SetRootUrl($"{defaultPath}posts").ToString(), false).ConfigureAwait(false);
+        }
+
         public async Task<IList<Post>> ListStickyPosts(bool embed = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
             return await GetRequest<Post[]>($"{defaultPath}posts?sticky=true", embed).ConfigureAwait(false);
+        }
+
+        public async Task<IList<Post>> ListStickyPosts(QueryBuilder builder)
+        {
+            // default values 
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return await GetRequest<Post[]>(builder.SetRootUrl($"{defaultPath}posts?sticky=true").ToString(), false).ConfigureAwait(false);
         }
 
         public async Task<IList<Post>> ListPostsByCategory(int categoryId, bool embed = false)
@@ -78,11 +92,25 @@ namespace WordPressPCL
             return await GetRequest<Post[]>($"{defaultPath}posts?categories={categoryId}", embed).ConfigureAwait(false);
         }
 
+        public async Task<IList<Post>> ListPostsByCategory(int categoryId, QueryBuilder builder)
+        {
+            // default values 
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return await GetRequest<Post[]>(builder.SetRootUrl($"{defaultPath}posts?categories={categoryId}").ToString(), false).ConfigureAwait(false);
+        }
+
         public async Task<IList<Post>> ListPostsByTag(int tagId, bool embed = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
             return await GetRequest<Post[]>($"{defaultPath}posts?tags={tagId}", embed).ConfigureAwait(false);
+        }
+
+        public async Task<IList<Post>> ListPostsByTag(int tagId, QueryBuilder builder)
+        {
+            // default values 
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return await GetRequest<Post[]>(builder.SetRootUrl($"{defaultPath}posts?tags={tagId}").ToString(), false).ConfigureAwait(false);
         }
 
         public async Task<IList<Post>> ListPostsByAuthor(int authorId, bool embed = false)
@@ -92,11 +120,25 @@ namespace WordPressPCL
             return await GetRequest<Post[]>($"{defaultPath}posts?author={authorId}", embed).ConfigureAwait(false);
         }
 
+        public async Task<IList<Post>> ListPostsByAuthor(int authorId, QueryBuilder builder)
+        {
+            // default values 
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return await GetRequest<Post[]>(builder.SetRootUrl($"{defaultPath}posts?author={authorId}").ToString(), false).ConfigureAwait(false);
+        }
+
         public async Task<IList<Post>> ListPostsBySearch(string searchTerm, bool embed = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
             return await GetRequest<Post[]>($"{defaultPath}posts?search={searchTerm}", embed).ConfigureAwait(false);
+        }
+
+        public async Task<IList<Post>> ListPostsBySearch(string searchTerm, QueryBuilder builder)
+        {
+            // default values 
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return await GetRequest<Post[]>(builder.SetRootUrl($"{defaultPath}posts?search={searchTerm}").ToString(), false).ConfigureAwait(false);
         }
 
         public async Task<Post> GetPost(int postId, bool embed = false)

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using WordPressPCL.Models;
+using WordPressPCL.Utility;
 
 namespace WordPressPCL
 {

--- a/WordPressPCLTests/ListPosts_QueryBuilder_Tests.cs
+++ b/WordPressPCLTests/ListPosts_QueryBuilder_Tests.cs
@@ -1,0 +1,145 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WordPressPCLTests.Utility;
+using WordPressPCL;
+using System.Threading.Tasks;
+using WordPressPCL.Models;
+using WordPressPCL.Utility;
+using System.Net;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace WordPressPCLTests
+{
+    [TestClass]
+    public class ListPosts_QueryBuilder_Tests
+    {
+        private const int CATEGORY_ID = 7;
+        private const int TAG_ID = 1;
+        private const int AUTHOR_ID = 1;
+        private const string SEARCH_TERM = "demo";
+
+        [TestInitialize]
+        public void Setup() {
+            ApiCredentials.WordPressUri = "https://demo.wp-api.org/wp-json/";
+        }
+
+        [TestMethod]
+        public async Task List_Posts_QueryBuilder_Test_Pagination()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListPosts(new QueryBuilder() {
+                page = 1
+            });
+            var postsB = await client.ListPosts(new QueryBuilder() {
+                page = 2
+            });
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            Assert.AreNotEqual(postsA.Count, 0);
+            Assert.AreNotEqual(postsB.Count, 0);
+            CollectionAssert.AreNotEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+
+        [TestMethod]
+        [Description("Test that the ListPosts method with the QueryBuilder override works the same way as before when `QueryBuilder` is set with default values")]
+        public async Task List_Posts_QueryBuilder_Works_The_Same_As_Before()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListPosts(new QueryBuilder());
+            var postsB = await client.ListPosts();
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            Assert.AreNotEqual(postsA.Count, 0);
+            Assert.AreNotEqual(postsB.Count, 0);
+            CollectionAssert.AreEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+
+        [TestMethod]
+        [Description("Test that the ListStickyPosts method with the QueryBuilder override works the same way as before when `QueryBuilder` is set with default values")]
+        public async Task List_Sticky_Posts_QueryBuilder_Works_The_Same_As_Before()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListStickyPosts(new QueryBuilder());
+            var postsB = await client.ListStickyPosts();
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            CollectionAssert.AreEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+
+        [TestMethod]
+        [Description("Test that the ListPostsByCategory method with the QueryBuilder override works the same way as before when `QueryBuilder` is set with default values")]
+        public async Task List_Posts_By_Category_QueryBuilder_Works_The_Same_As_Before()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListPostsByCategory(CATEGORY_ID, new QueryBuilder());
+            var postsB = await client.ListPostsByCategory(CATEGORY_ID);
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            Assert.AreNotEqual(postsA.Count, 0);
+            Assert.AreNotEqual(postsB.Count, 0);
+            CollectionAssert.AreEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+
+        [TestMethod]
+        [Description("Test that the ListPostsByTag method with the QueryBuilder override works the same way as before when `QueryBuilder` is set with default values")]
+        public async Task List_Posts_By_Tag_QueryBuilder_Works_The_Same_As_Before()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListPostsByTag(TAG_ID, new QueryBuilder());
+            var postsB = await client.ListPostsByTag(TAG_ID);
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            CollectionAssert.AreEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+
+        [TestMethod]
+        [Description("Test that the ListPostsByAuthor method with the QueryBuilder override works the same way as before when `QueryBuilder` is set with default values")]
+        public async Task List_Posts_By_Author_QueryBuilder_Works_The_Same_As_Before()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListPostsByAuthor(AUTHOR_ID, new QueryBuilder());
+            var postsB = await client.ListPostsByAuthor(AUTHOR_ID);
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            Assert.AreNotEqual(postsA.Count, 0);
+            Assert.AreNotEqual(postsB.Count, 0);
+            CollectionAssert.AreEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+
+        [TestMethod]
+        [Description("Test that the ListPostsBySearch method with the QueryBuilder override works the same way as before when `QueryBuilder` is set with default values")]
+        public async Task List_Posts_By_Search_QueryBuilder_Works_The_Same_As_Before()
+        {
+            // Initialize
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            Assert.IsNotNull(client);
+            // Posts
+            var postsA = await client.ListPostsBySearch(SEARCH_TERM, new QueryBuilder());
+            var postsB = await client.ListPostsBySearch(SEARCH_TERM);
+            Assert.IsNotNull(postsA);
+            Assert.IsNotNull(postsB);
+            Assert.AreNotEqual(postsA.Count, 0);
+            Assert.AreNotEqual(postsB.Count, 0);
+            CollectionAssert.AreEqual(postsA.Select(post => post.Id).ToList(), postsB.Select(post => post.Id).ToList());
+        }
+    }
+}

--- a/WordPressPCLTests/ListPosts_QueryBuilder_Tests.cs
+++ b/WordPressPCLTests/ListPosts_QueryBuilder_Tests.cs
@@ -32,10 +32,10 @@ namespace WordPressPCLTests
             Assert.IsNotNull(client);
             // Posts
             var postsA = await client.ListPosts(new QueryBuilder() {
-                page = 1
+                Page = 1
             });
             var postsB = await client.ListPosts(new QueryBuilder() {
-                page = 2
+                Page = 2
             });
             Assert.IsNotNull(postsA);
             Assert.IsNotNull(postsB);


### PR DESCRIPTION
Hello,

I needed to fetch information from multiple pages and worked with this project ... I found it really helpful. Thanks!

I added an override method for the `ListPosts...` methods in WordpressClient.cs -> the `QueryBuilder` class

This contains attributes that would resolve into querystrings for manipulating the WordPress API ...

A good example is pagination, so one can go to a page of the `ListPosts` results via the following code

```cs
var client = new WordpressClient("https://demo.wp-api.org/wp-json/");
await client.ListPosts(new QueryBuilder() {
   page = 2
});
```

This would return the page 2 of the results.

Other attributes include:

- `per_page` which is 10 by default, and controls the number of posts shown on a page.
- `offset` is 0 by default ... I assume this controls the number of posts to skip
- `orderBy` is an enum and is `OrderBy.date` by default
- `embed` is a boolean and is `false` by default <... This could reduce the complexity of the `GetRequest` method in the `WordpressClient` class by eliminating the need for its `embed` parameter.

I hope this is useful 🙂