### PR TITLE
Add support for ACF - "Advanced Custom Fields" (Issue-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,27 @@ var client = new WordPressClient("http://demo.wp-api.org/wp-json/wp/v2/");
 var posts = await client.ListPosts();
 var postbyid = await client.GetPost(id);
 
+// Creating post
+var newPost = new PostCreate()
+{
+	Title = "Hi, From C#!",
+	Content = "Test <b>simple content</b>"
+};
+var resultPost = await client.CreatePost(newPost);
+
+// Creating post with Advanced Custom Fields
+ var newPost = new PostCreate()
+{
+	Title = "Hi, From C#!",
+	Content = "Test with <b>Advanced Custom Fields</b>",
+    Fields = new Dictionary<string, string>()
+    {
+		{ "projectyear", "2017" },
+		{ "projectowner", "wp-net" }
+    }
+};
+var resultPost = await client.CreatePost(newPost);
+
 // Comments
 var comments = await client.ListComments();
 var commentbyid = await client.GetComment(id);

--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ var postbyid = await client.GetPost(id);
 // Creating post
 var newPost = new PostCreate()
 {
-	Title = "Hi, From C#!",
-	Content = "Test <b>simple content</b>"
+    Title = "Hi, From C#!",
+    Content = "Test <b>simple content</b>"
 };
 var resultPost = await client.CreatePost(newPost);
 
 // Creating post with Advanced Custom Fields
  var newPost = new PostCreate()
 {
-	Title = "Hi, From C#!",
-	Content = "Test with <b>Advanced Custom Fields</b>",
+    Title = "Hi, From C#!",
+    Content = "Test with <b>Advanced Custom Fields</b>",
     Fields = new Dictionary<string, string>()
     {
-		{ "projectyear", "2017" },
-		{ "projectowner", "wp-net" }
+        { "projectyear", "2017" },
+        { "projectowner", "wp-net" }
     }
 };
 var resultPost = await client.CreatePost(newPost);

--- a/WordPressPCL/Models/Post.cs
+++ b/WordPressPCL/Models/Post.cs
@@ -103,6 +103,12 @@ namespace WordPressPCL.Models
 
         [JsonProperty("_embedded")]
         public Embedded Embedded { get; set; }
+
+        /// <summary>
+        /// ACF - Advanced Custom Fields
+        /// </summary>
+        [JsonProperty("acf")]
+        public Dictionary<string, string> Fields { get; set; }
     }
 
     public class Embedded

--- a/WordPressPCL/Models/PostCreate.cs
+++ b/WordPressPCL/Models/PostCreate.cs
@@ -27,10 +27,17 @@ namespace WordPressPCL.Models
         [JsonProperty("title")]
         public string Title { get; set; }
 
+        /// <summary>
+        /// ACF - Advanced Custom Fields
+        /// </summary>
+        [JsonProperty("fields")]
+        public Dictionary<string, string> Fields { get; set; }
+
         public PostCreate()
         {
             Date = DateTime.Now;
             DateGmt = DateTime.UtcNow;
+            Fields = new Dictionary<string, string>();
         }
     }
 }

--- a/WordPressPCLTests/UnitTest1.cs
+++ b/WordPressPCLTests/UnitTest1.cs
@@ -116,11 +116,8 @@ namespace WordPressPCLTests
         [TestMethod]
         public async Task JWTAuthTest()
         {
-            var client = new WordPressClient(ApiCredentials.WordPressUri);
-            client.Username = ApiCredentials.Username;
-            client.Password = ApiCredentials.Password;
-            client.AuthMethod = AuthMethod.JWT;
-            await client.RequestJWToken();
+            var client = await GetAuthenticatedWordPressClient();
+
             Assert.IsNotNull(client.JWToken);
             var IsValidToken = await client.IsValidJWToken();
             Assert.IsTrue(IsValidToken);
@@ -129,11 +126,7 @@ namespace WordPressPCLTests
         [TestMethod]
         public async Task CreateAndDeleteComment()
         {
-            var client = new WordPressClient(ApiCredentials.WordPressUri);
-            client.Username = ApiCredentials.Username;
-            client.Password = ApiCredentials.Password;
-            client.AuthMethod = AuthMethod.JWT;
-            await client.RequestJWToken();
+            var client = await GetAuthenticatedWordPressClient();
             var IsValidToken = await client.IsValidJWToken();
             Assert.IsTrue(IsValidToken);
 
@@ -165,11 +158,8 @@ namespace WordPressPCLTests
         [TestMethod]
         public async Task CreateAndDeletePostTest()
         {
-            var client = new WordPressClient(ApiCredentials.WordPressUri);
-            client.Username = ApiCredentials.Username;
-            client.Password = ApiCredentials.Password;
-            client.AuthMethod = AuthMethod.JWT;
-            await client.RequestJWToken();
+            WordPressClient client = await GetAuthenticatedWordPressClient();
+
             var IsValidToken = await client.IsValidJWToken();
             Assert.IsTrue(IsValidToken);
             var newpost = new PostCreate()
@@ -183,6 +173,17 @@ namespace WordPressPCLTests
             Assert.IsTrue(del.IsSuccessStatusCode);
 
 
+        }
+
+        private static async Task<WordPressClient> GetAuthenticatedWordPressClient()
+        {
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            client.Username = ApiCredentials.Username;
+            client.Password = ApiCredentials.Password;
+            client.AuthMethod = AuthMethod.JWT;
+            await client.RequestJWToken();
+
+            return client;
         }
     }
 }


### PR DESCRIPTION
Code is solving problem described in issue https://github.com/wp-net/WordPressPCL/issues/8

I'm using "fields" as property name as it is also used when posting back to REST API and it sounds more descriptive as ACF.

What was done:
- ACF added on posts read
- ACF added to posts create
- readme file updated