### PR TITLE
Create media with attachment and create constructors with required parameters

### DIFF
--- a/WordPressPCL/Client/Categories.cs
+++ b/WordPressPCL/Client/Categories.cs
@@ -36,10 +36,11 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Categories query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered categories</returns>
-        public async Task<IEnumerable<Category>> Query(CategoriesQueryBuilder queryBuilder)
+        public async Task<IEnumerable<Category>> Query(CategoriesQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Category>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Category>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
@@ -75,8 +76,9 @@ namespace WordPressPCL.Client
         /// Get All Categories
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Categories</returns>
-        public async Task<IEnumerable<Category>> GetAll(bool embed = false)
+        public async Task<IEnumerable<Category>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             List<Category> categories = new List<Category>();
@@ -84,7 +86,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                categories_page = (await _httpHelper.GetRequest<IEnumerable<Category>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<Category>();
+                categories_page = (await _httpHelper.GetRequest<IEnumerable<Category>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<Category>();
                 if (categories_page != null && categories_page.Count > 0) { categories.AddRange(categories_page); }
 
             } while (categories_page != null && categories_page.Count > 0);
@@ -97,10 +99,11 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="ID">Category ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>Category by Id</returns>
-        public async Task<Category> GetByID(int ID, bool embed = false)
+        public async Task<Category> GetByID(int ID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<Category>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<Category>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
 
         #endregion

--- a/WordPressPCL/Client/Comments.cs
+++ b/WordPressPCL/Client/Comments.cs
@@ -37,10 +37,11 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Comments query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered comments</returns>
-        public async Task<IEnumerable<Comment>> Query(CommentsQueryBuilder queryBuilder)
+        public async Task<IEnumerable<Comment>> Query(CommentsQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Comment>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Comment>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
@@ -76,8 +77,9 @@ namespace WordPressPCL.Client
         /// Get All Comments
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Comments</returns>
-        public async Task<IEnumerable<Comment>> GetAll(bool embed = false)
+        public async Task<IEnumerable<Comment>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             List<Comment> comments = new List<Comment>();
@@ -85,7 +87,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                comments_page = (await _httpHelper.GetRequest<IEnumerable<Comment>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<Comment>();
+                comments_page = (await _httpHelper.GetRequest<IEnumerable<Comment>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<Comment>();
                 if (comments_page != null && comments_page.Count>0) { comments.AddRange(comments_page); }
 
             } while (comments_page != null && comments_page.Count > 0);
@@ -100,13 +102,14 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="ID">Comment ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>Comment by Id</returns>
-        public async Task<Comment> GetByID(int ID, bool embed = false)
+        public async Task<Comment> GetByID(int ID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<Comment>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<Comment>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
 
-        
+
         #endregion
 
         #region Custom
@@ -115,10 +118,11 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="PostID">Post id</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of comments for post</returns>
-        public async Task<IEnumerable<Comment>> GetCommentsForPost(string PostID, bool embed = false)
+        public async Task<IEnumerable<Comment>> GetCommentsForPost(string PostID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Comment>>($"{_defaultPath}{_methodPath}?post={PostID}", embed);
+            return await _httpHelper.GetRequest<IEnumerable<Comment>>($"{_defaultPath}{_methodPath}?post={PostID}", embed,useAuth);
         }
         /// <summary>
         /// Force deletion of comments

--- a/WordPressPCL/Client/Media.cs
+++ b/WordPressPCL/Client/Media.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Net.Http;
 using Newtonsoft.Json;
 using WordPressPCL.Models;
+using System.IO;
 
 namespace WordPressPCL.Client
 {
@@ -36,21 +37,37 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Media query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered Media</returns>
-        public async Task<IEnumerable<Media>> Query(MediaQueryBuilder queryBuilder)
+        public async Task<IEnumerable<Media>> Query(MediaQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Media>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Media>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
-        /// Create Media
+        /// Create Empty Media
         /// </summary>
         /// <param name="Entity">Media object</param>
         /// <returns>Created media object</returns>
         public async Task<MediaItem> Create(MediaItem Entity)
         {
-            var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
-            return (await _httpHelper.PostRequest<MediaItem>($"{_defaultPath}{_methodPath}", postBody)).Item1;
+            throw new InvalidOperationException("Use Create(fileStream,fileName) instead of this method");
+            /*var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            return (await _httpHelper.PostRequest<MediaItem>($"{_defaultPath}{_methodPath}", postBody)).Item1;*/
+        }
+        /// <summary>
+        /// Create Media entity with attachment
+        /// </summary>
+        /// <param name="fileStream">stream with file content</param>
+        /// <param name="filename">Name of file in WP Media Library</param>
+        /// <returns>Created media object</returns>
+        public async Task<MediaItem> Create(Stream fileStream,string filename)
+        {
+            StreamContent content = new StreamContent(fileStream);
+            string extension = filename.Split('.').Last();
+            content.Headers.TryAddWithoutValidation("Content-Type", MimeTypeHelper.GetMIMETypeFromExtension(extension));
+            content.Headers.TryAddWithoutValidation("Content-Disposition", $"attachment; filename={filename}");
+            return (await _httpHelper.PostRequest<MediaItem>($"{_defaultPath}{_methodPath}", content)).Item1;
         }
         /// <summary>
         /// Update Media
@@ -75,8 +92,9 @@ namespace WordPressPCL.Client
         /// Get All Media
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Media</returns>
-        public async Task<IEnumerable<MediaItem>> GetAll(bool embed = false)
+        public async Task<IEnumerable<MediaItem>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             var medias = new List<MediaItem>();
@@ -84,7 +102,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                medias_page = (await _httpHelper.GetRequest<IEnumerable<MediaItem>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<MediaItem>();
+                medias_page = (await _httpHelper.GetRequest<IEnumerable<MediaItem>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<MediaItem>();
                 if (medias_page != null && medias_page.Count > 0) { medias.AddRange(medias_page); }
 
             } while (medias_page != null && medias_page.Count > 0);
@@ -97,10 +115,11 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="ID">Media ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>Media by Id</returns>
-        public async Task<MediaItem> GetByID(int ID, bool embed = false)
+        public async Task<MediaItem> GetByID(int ID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<MediaItem>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<MediaItem>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
         /// <summary>
         /// Force deletion of media

--- a/WordPressPCL/Client/Pages.cs
+++ b/WordPressPCL/Client/Pages.cs
@@ -36,10 +36,11 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Pages query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered pages</returns>
-        public async Task<IEnumerable<Page>> Query(PagesQueryBuilder queryBuilder)
+        public async Task<IEnumerable<Page>> Query(PagesQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
@@ -75,8 +76,9 @@ namespace WordPressPCL.Client
         /// Get All Pages
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Pages</returns>
-        public async Task<IEnumerable<Page>> GetAll(bool embed = false)
+        public async Task<IEnumerable<Page>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             List<Page> posts = new List<Page>();
@@ -84,7 +86,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                posts_page = (await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<Page>();
+                posts_page = (await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<Page>();
                 if (posts_page != null && posts_page.Count > 0) { posts.AddRange(posts_page); }
 
             } while (posts_page != null && posts_page.Count > 0);
@@ -96,39 +98,42 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="ID">Page ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>Page by Id</returns>
-        public async Task<Page> GetByID(int ID, bool embed = false)
+        public async Task<Page> GetByID(int ID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<Page>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<Page>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
         #endregion
 
         #region Custom
-        
+
         /// <summary>
         /// Get pages by its author
         /// </summary>
         /// <param name="authorId">Author id</param>
         /// <param name="embed">includ embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of pages</returns>
-        public async Task<IEnumerable<Page>> GetPagesByAuthor(int authorId, bool embed = false)
+        public async Task<IEnumerable<Page>> GetPagesByAuthor(int authorId, bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}?author={authorId}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}?author={authorId}", embed,useAuth).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Get pages by search term
         /// </summary>
         /// <param name="searchTerm">Search term</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of pages</returns>
-        public async Task<IEnumerable<Page>> GetPagesBySearch(string searchTerm, bool embed = false)
+        public async Task<IEnumerable<Page>> GetPagesBySearch(string searchTerm, bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}?search={searchTerm}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Page>>($"{_defaultPath}{_methodPath}?search={searchTerm}", embed,useAuth).ConfigureAwait(false);
         }
         
         /// <summary>

--- a/WordPressPCL/Client/Posts.cs
+++ b/WordPressPCL/Client/Posts.cs
@@ -38,10 +38,11 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Posts query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered posts</returns>
-        public async Task<IEnumerable<Post>> Query(PostsQueryBuilder queryBuilder)
+        public async Task<IEnumerable<Post>> Query(PostsQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}",false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}",false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
@@ -78,8 +79,9 @@ namespace WordPressPCL.Client
         /// Get All Posts
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Posts</returns>
-        public async Task<IEnumerable<Post>> GetAll(bool embed=false)
+        public async Task<IEnumerable<Post>> GetAll(bool embed=false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             List<Post> posts = new List<Post>();
@@ -87,7 +89,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                posts_page = (await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<Post>();
+                posts_page = (await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<Post>();
                 if (posts_page != null && posts_page.Count>0) { posts.AddRange(posts_page); }
                 
             } while (posts_page!=null && posts_page.Count > 0);
@@ -101,10 +103,11 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="ID">Post ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>Post by Id</returns>
-        public async Task<Post> GetByID(int ID, bool embed=false)
+        public async Task<Post> GetByID(int ID, bool embed=false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<Post>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<Post>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
         #endregion
 
@@ -113,64 +116,69 @@ namespace WordPressPCL.Client
         /// Get sticky posts
         /// </summary>
         /// <param name="embed">includ embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of posts</returns>
-        public async Task<IEnumerable<Post>> GetStickyPosts(bool embed = false)
+        public async Task<IEnumerable<Post>> GetStickyPosts(bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?sticky=true", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?sticky=true", embed,useAuth).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Get posts by category
         /// </summary>
         /// <param name="categoryId">Category Id</param>
         /// <param name="embed">includ embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of posts</returns>
-        public async Task<IEnumerable<Post>> GetPostsByCategory(int categoryId, bool embed = false)
+        public async Task<IEnumerable<Post>> GetPostsByCategory(int categoryId, bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?categories={categoryId}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?categories={categoryId}", embed,useAuth).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Get posts by tag
         /// </summary>
         /// <param name="tagId">Tag Id</param>
         /// <param name="embed">includ embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of posts</returns>
-        public async Task<IEnumerable<Post>> GetPostsByTag(int tagId, bool embed = false)
+        public async Task<IEnumerable<Post>> GetPostsByTag(int tagId, bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?tags={tagId}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?tags={tagId}", embed,useAuth).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Get posts by its author
         /// </summary>
         /// <param name="authorId">Author id</param>
         /// <param name="embed">includ embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of posts</returns>
-        public async Task<IEnumerable<Post>> GetPostsByAuthor(int authorId, bool embed = false)
+        public async Task<IEnumerable<Post>> GetPostsByAuthor(int authorId, bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?author={authorId}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?author={authorId}", embed,useAuth).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Get posts by search term
         /// </summary>
         /// <param name="searchTerm">Search term</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of posts</returns>
-        public async Task<IEnumerable<Post>> GetPostsBySearch(string searchTerm, bool embed = false)
+        public async Task<IEnumerable<Post>> GetPostsBySearch(string searchTerm, bool embed = false, bool useAuth = false)
         {
             // default values 
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?search={searchTerm}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Post>>($"{_defaultPath}{_methodPath}?search={searchTerm}", embed,useAuth).ConfigureAwait(false);
         }
         
         /// <summary>

--- a/WordPressPCL/Client/Tags.cs
+++ b/WordPressPCL/Client/Tags.cs
@@ -38,10 +38,11 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Tags query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered tags</returns>
-        public async Task<IEnumerable<Tag>> Query(TagsQueryBuilder queryBuilder)
+        public async Task<IEnumerable<Tag>> Query(TagsQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<Tag>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<Tag>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
@@ -77,8 +78,9 @@ namespace WordPressPCL.Client
         /// Get All Tags
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Tags</returns>
-        public async Task<IEnumerable<Tag>> GetAll(bool embed = false)
+        public async Task<IEnumerable<Tag>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             List<Tag> tags = new List<Tag>();
@@ -86,7 +88,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                tags_page = (await _httpHelper.GetRequest<IEnumerable<Tag>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<Tag>();
+                tags_page = (await _httpHelper.GetRequest<IEnumerable<Tag>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<Tag>();
                 if (tags_page != null && tags_page.Count > 0) { tags.AddRange(tags_page); }
 
             } while (tags_page != null && tags_page.Count > 0);
@@ -101,10 +103,11 @@ namespace WordPressPCL.Client
         /// </summary>
         /// <param name="ID">Tag ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>Tag by Id</returns>
-        public async Task<Tag> GetByID(int ID, bool embed = false)
+        public async Task<Tag> GetByID(int ID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<Tag>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<Tag>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
 
         #endregion

--- a/WordPressPCL/Client/Users.cs
+++ b/WordPressPCL/Client/Users.cs
@@ -37,10 +37,11 @@ namespace WordPressPCL.Client
         /// Create a parametrized query and get a result
         /// </summary>
         /// <param name="queryBuilder">Users query builder with specific parameters</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of filtered users</returns>
-        public async Task<IEnumerable<User>> Query(UsersQueryBuilder queryBuilder)
+        public async Task<IEnumerable<User>> Query(UsersQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false,useAuth).ConfigureAwait(false);
         }
         #region Interface Realisation
         /// <summary>
@@ -76,8 +77,9 @@ namespace WordPressPCL.Client
         /// Get All Users
         /// </summary>
         /// <param name="embed">Include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>List of all Users</returns>
-        public async Task<IEnumerable<User>> GetAll(bool embed = false)
+        public async Task<IEnumerable<User>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
             List<User> users = new List<User>();
@@ -85,7 +87,7 @@ namespace WordPressPCL.Client
             int page = 1;
             do
             {
-                users_page = (await _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed).ConfigureAwait(false))?.ToList<User>();
+                users_page = (await _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{_methodPath}?per_page=100&page={page++}", embed,useAuth).ConfigureAwait(false))?.ToList<User>();
                 if (users_page != null && users_page.Count > 0) { users.AddRange(users_page); }
 
             } while (users_page != null && users_page.Count > 0);
@@ -94,16 +96,17 @@ namespace WordPressPCL.Client
             //return await _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{_methodPath}", embed).ConfigureAwait(false);
         }
 
-        
+
         /// <summary>
         /// GetUser by Id
         /// </summary>
         /// <param name="ID">User ID</param>
         /// <param name="embed">include embed info</param>
+        /// <param name="useAuth">Send request with authenication header</param>
         /// <returns>User by Id</returns>
-        public async Task<User> GetByID(int ID, bool embed = false)
+        public async Task<User> GetByID(int ID, bool embed = false, bool useAuth = false)
         {
-            return await _httpHelper.GetRequest<User>($"{_defaultPath}{_methodPath}/{ID}", embed).ConfigureAwait(false);
+            return await _httpHelper.GetRequest<User>($"{_defaultPath}{_methodPath}/{ID}", embed,useAuth).ConfigureAwait(false);
         }
 
         

--- a/WordPressPCL/Interfaces/ICRUDOperation.cs
+++ b/WordPressPCL/Interfaces/ICRUDOperation.cs
@@ -9,10 +9,10 @@ namespace WordPressPCL.Interfaces
 {
     interface ICRUDOperationAsync<TClass>
     {
-        Task<TClass> GetByID(int ID, bool embed=false);
+        Task<TClass> GetByID(int ID, bool embed=false,bool useAuth=false);
         //IEnumerable<TClass> GetBy(Func<TClass, bool> predicate, bool embed=false);
         //Task<IEnumerable<TClass>> GetBy(QueryBuilder builder);
-        Task<IEnumerable<TClass>> GetAll(bool embed=false);
+        Task<IEnumerable<TClass>> GetAll(bool embed=false, bool useAuth = false);
         Task<TClass> Create(TClass Entity);
         Task<TClass> Update(TClass Entity);
         Task<HttpResponseMessage> Delete(int ID);

--- a/WordPressPCL/Models/Category.cs
+++ b/WordPressPCL/Models/Category.cs
@@ -40,7 +40,21 @@ namespace WordPressPCL.Models
         /// <remarks>Context: view, edit</remarks>
         [JsonProperty("meta", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IList<object> Meta { get; set; }
+        /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        public Category():base()
+        {
 
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        public Category(string name):this()
+        {
+            Name = name;
+        }
     }
 
 }

--- a/WordPressPCL/Models/Comment.cs
+++ b/WordPressPCL/Models/Comment.cs
@@ -75,12 +75,13 @@ namespace WordPressPCL.Models
         /// The date the object was published.
         /// </summary>
         /// <remarks>Context: view, edit, embed</remarks>
+        [JsonProperty("date", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime Date { get; set; }
         /// <summary>
         /// The date the object was published as GMT.
         /// </summary>
         /// <remarks>Context: view, edit</remarks>
-		[JsonProperty("date_gmt")]
+		[JsonProperty("date_gmt", DefaultValueHandling = DefaultValueHandling.Ignore)]
 		public DateTime DateGmt { get; set; }
         /// <summary>
         /// The content for the object.
@@ -115,7 +116,27 @@ namespace WordPressPCL.Models
         /// </summary>
         /// <remarks>Context: edit</remarks>
         public int Karma { get; set; }
-		//public Links _links { get; set; }
+        /// <summary>
+        /// Links to another entities
+        /// </summary>
+        public Links _links { get; set; }
+        /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        public Comment()
+        {
+
+        }
+        /// <summary>
+        /// Constructor with required parameters
+        /// </summary>
+        /// <param name="postId">Post ID</param>
+        /// <param name="content">Comment content</param>
+        public Comment(int postId,string content):this()
+        {
+            PostId = postId;
+            Content = new Content(content);
+        }
 	}
 
 	

--- a/WordPressPCL/Models/Embedded.cs
+++ b/WordPressPCL/Models/Embedded.cs
@@ -33,5 +33,10 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("wp:term")]
         public IEnumerable<IEnumerable<Term>> WpTerm { get; set; }
+        /// <summary>
+        /// Parent page
+        /// </summary>
+        [JsonProperty("up")]
+        public IEnumerable<Page> Up { get; set; }
     }
 }

--- a/WordPressPCL/Models/Enums.cs
+++ b/WordPressPCL/Models/Enums.cs
@@ -84,7 +84,7 @@ namespace WordPressPCL.Models
     /// Status of Media for query builder
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
-    public enum MediaStatus
+    public enum MediaQueryStatus
     {
         /// <summary>
         /// Media inherit

--- a/WordPressPCL/Models/Links.cs
+++ b/WordPressPCL/Models/Links.cs
@@ -37,5 +37,35 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("curies")]
         public IEnumerable<Cury> Curies { get; set; }
+        /// <summary>
+        /// Author
+        /// </summary>
+        [JsonProperty("author")]
+        public IEnumerable<Author> Author { get; set; }
+        /// <summary>
+        /// Replies
+        /// </summary>
+        [JsonProperty("replies")]
+        public IEnumerable<Reply> Replies { get; set; }
+        /// <summary>
+        /// Versions
+        /// </summary>
+        [JsonProperty("version-history")]
+        public IEnumerable<VersionHistory> Versions { get; set; }
+        /// <summary>
+        /// Attachment
+        /// </summary>
+        [JsonProperty("wp:attachment")]
+        public IEnumerable<HttpsApiWOrgAttachment> Attachment { get; set; }
+        /// <summary>
+        /// Featured media
+        /// </summary>
+        [JsonProperty("wp:featuredmedia")]
+        public IEnumerable<HttpsApiWOrgFeaturedmedia> FeaturedMedia { get; set; }
+        /// <summary>
+        /// Featured media
+        /// </summary>
+        [JsonProperty("wp:term")]
+        public IEnumerable<HttpsApiWOrgTerm> Term { get; set; }
     }
 }

--- a/WordPressPCL/Models/MediaDetails.cs
+++ b/WordPressPCL/Models/MediaDetails.cs
@@ -30,7 +30,7 @@ namespace WordPressPCL.Models
         /// Sizes
         /// </summary>
         [JsonProperty("sizes")]
-        public Dictionary<string, MediaSize> Sizes { get; set; }
+        public IDictionary<string, MediaSize> Sizes { get; set; }
         /// <summary>
         /// Meta info of Image
         /// </summary>

--- a/WordPressPCL/Models/MediaItem.cs
+++ b/WordPressPCL/Models/MediaItem.cs
@@ -15,37 +15,37 @@ namespace WordPressPCL.Models
         /// Unique identifier for the object.
         /// </summary>
         /// <remarks>Context: view, edit, embed</remarks>
-        [JsonProperty("id")]
+        [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int Id { get; set; }
         /// <summary>
         /// The date the object was published, in the site’s timezone.
         /// </summary>
         /// <remarks>Context: view, edit, embed</remarks>
-        [JsonProperty("date")]
+        [JsonProperty("date", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime Date { get; set; }
         /// <summary>
         /// The date the object was published, as GMT.
         /// </summary>
         /// <remarks>Context: view, edit</remarks>
-        [JsonProperty("date_gmt")]
+        [JsonProperty("date_gmt", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime DateGmt { get; set; }
         /// <summary>
         /// The globally unique identifier for the object.
         /// </summary>
         /// <remarks>Context: view, edit</remarks>
-        [JsonProperty("guid")]
+        [JsonProperty("guid", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Guid Guid { get; set; }
         /// <summary>
         /// The date the object was last modified, in the site’s timezone.
         /// </summary>
         /// <remarks>Context: view, edit</remarks>
-        [JsonProperty("modified")]
+        [JsonProperty("modified", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime Modified { get; set; }
         /// <summary>
         /// The date the object was last modified, as GMT.
         /// </summary>
         /// <remarks>Context: view, edit</remarks>
-        [JsonProperty("modified_gmt")]
+        [JsonProperty("modified_gmt", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime ModifiedGmt { get; set; }
         /// <summary>
         /// An alphanumeric identifier for the object unique to its type.
@@ -60,8 +60,8 @@ namespace WordPressPCL.Models
         /// <remarks>
         /// Context: edit
         /// One of: publish, future, draft, pending, private</remarks>
-        [JsonProperty("status")]
-        public MediaStatus Status { get; set; }
+        [JsonProperty("status",DefaultValueHandling=DefaultValueHandling.Ignore)]
+        public MediaQueryStatus Status { get; set; }
         /// <summary>
         /// Type of Post for the object.
         /// </summary>
@@ -168,6 +168,13 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("_links")]
         public Links Links { get; set; }
+        /// <summary>
+        /// Paremeterless constructor
+        /// </summary>
+        public MediaItem()
+        {
+
+        }
     }
 
 }

--- a/WordPressPCL/Models/Page.cs
+++ b/WordPressPCL/Models/Page.cs
@@ -24,7 +24,7 @@ namespace WordPressPCL.Models
         /// The date the object was published, in the site’s timezone.
         /// </summary>
         /// <remarks>Context: view, edit, embed</remarks>
-        [JsonProperty("date")]
+        [JsonProperty("date", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime Date { get; set; }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace WordPressPCL.Models
         /// Read only
         /// Context: view, edit
         /// </remarks>
-        [JsonProperty("modified")]
+        [JsonProperty("modified", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime Modified { get; set; }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace WordPressPCL.Models
         /// Read only
         /// Context: view, edit
         /// </remarks>
-        [JsonProperty("modified_gmt")]
+        [JsonProperty("modified_gmt", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public DateTime ModifiedGmt { get; set; }
 
         /// <summary>
@@ -195,6 +195,13 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("_embedded")]
         public Embedded Embedded { get; set; }
+        /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        public Page()
+        {
+
+        }
     }
 
 }

--- a/WordPressPCL/Models/Post.cs
+++ b/WordPressPCL/Models/Post.cs
@@ -227,6 +227,15 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("_embedded")]
         public Embedded Embedded { get; set; }
+        /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        public Post()
+        {
+                
+        }
+        
+        
     }
 
    

--- a/WordPressPCL/Models/Subclasses.cs
+++ b/WordPressPCL/Models/Subclasses.cs
@@ -165,6 +165,32 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("protected")]
         public bool IsProtected { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public Excerpt()
+        {
+
+        }
+        /// <summary>
+        /// Constructor with same Raw and rendered Excerpt
+        /// </summary>
+        /// <param name="Excerpt">Text for Excerpt</param>
+        public Excerpt(string Excerpt) : this(Excerpt, Excerpt)
+        {
+
+        }
+        /// <summary>
+        /// Constructor with Raw and rendered text
+        /// </summary>
+        /// <param name="ExcerptRaw">Raw HTML text for Excerpt</param>
+        /// <param name="ExcerptRendered">Rendered text for Excerpt</param>
+        public Excerpt(string ExcerptRaw, string ExcerptRendered)
+        {
+            Raw = ExcerptRaw;
+            Rendered = ExcerptRendered;
+        }
     }
 
     /// <summary>
@@ -176,7 +202,33 @@ namespace WordPressPCL.Models
     /// <summary>
     /// Caption
     /// </summary>
-    public class Caption : RenderedRawBase { }
+    public class Caption : RenderedRawBase {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public Caption()
+        {
+
+        }
+        /// <summary>
+        /// Constructor with the same raw and rendered Caption
+        /// </summary>
+        /// <param name="Caption">Text for caption</param>
+        public Caption(string Caption):this(Caption,Caption)
+        {
+
+        }
+        /// <summary>
+        /// Constructor with raw and rendered caption
+        /// </summary>
+        /// <param name="CaptionRaw">Raw text for caption</param>
+        /// <param name="CaptionRendered">Rendered text for caption</param>
+        public Caption(string CaptionRaw,string CaptionRendered)
+        {
+            Raw = CaptionRaw;
+            Rendered = CaptionRendered;
+        }
+    }
     /// <summary>
     /// Multimedia http info
     /// </summary>
@@ -255,6 +307,7 @@ namespace WordPressPCL.Models
         /// <summary>
         /// Taxonomy name
         /// </summary>
+        [JsonProperty("taxonomy")]
         public string Taxonomy { get; set; }
         /// <summary>
         /// Has embedded info

--- a/WordPressPCL/Models/Tag.cs
+++ b/WordPressPCL/Models/Tag.cs
@@ -30,5 +30,20 @@ namespace WordPressPCL.Models
         /// <remarks>Context: view</remarks>
         [JsonProperty("meta", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IEnumerable<object> Meta { get; set; }
+        /// <summary>
+        /// Parameterless constructor
+        /// </summary>
+        public Tag():base()
+        {
+
+        }
+        /// <summary>
+        /// Constructor with required parameters
+        /// </summary>
+        /// <param name="name">Tag name</param>
+        public Tag(string name):this()
+        {
+            Name = name;
+        }
     }
 }

--- a/WordPressPCL/Models/Term.cs
+++ b/WordPressPCL/Models/Term.cs
@@ -57,5 +57,12 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("_links")]
         public Links Links { get; set; }
+        /// <summary>
+        /// parameterless constructor
+        /// </summary>
+        public Term()
+        {
+
+        }
     }
 }

--- a/WordPressPCL/Models/User.cs
+++ b/WordPressPCL/Models/User.cs
@@ -72,13 +72,13 @@ namespace WordPressPCL.Models
         /// Read only
         /// Context: embed, view, edit
         /// </remarks>
-        [JsonProperty("link")]
+        [JsonProperty("link",DefaultValueHandling =DefaultValueHandling.Ignore)]
         public string Link { get; set; }
         /// <summary>
         /// Locale for the user.
         /// </summary>
         /// <remarks>Context: edit</remarks>
-        [JsonProperty("locale")]
+        [JsonProperty("locale", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Locale { get; set; }
         /// <summary>
         /// The nickname for the user.
@@ -103,26 +103,26 @@ namespace WordPressPCL.Models
         /// Roles assigned to the user.
         /// </summary>
         /// <remarks>Context: edit</remarks>
-        [JsonProperty("roles")]
+        [JsonProperty("roles", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public IEnumerable<string> Roles { get; set; }
         /// <summary>
         /// Password for the user (never included).
         /// </summary>
         /// <remarks>Context:</remarks>
-        [JsonProperty("password")]
+        [JsonProperty("password", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string Password { get; set; }
         /// <summary>
         /// All capabilities assigned to the user.
         /// </summary>
         /// <remarks>Context: edit</remarks>
-        [JsonProperty("capabilities")]
-        public IEnumerable<object> Capabilities { get; set; }
+        [JsonProperty("capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public IDictionary<string,bool> Capabilities { get; set; }
         /// <summary>
         /// Any extra capabilities assigned to the user.
         /// </summary>
         /// <remarks>Context: edit</remarks>
-        [JsonProperty("extra_capabilities")]
-        public IEnumerable<object> ExtraCapabilities { get; set; }
+        [JsonProperty("extra_capabilities", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public IDictionary<string,bool> ExtraCapabilities { get; set; }
 
         /// <summary>
         /// Avatar URLs for the user.
@@ -146,6 +146,25 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("_links", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public Links Links { get; set; }
+        /// <summary>
+        /// Constructor with required parameters
+        /// </summary>
+        /// <param name="userName">Username</param>
+        /// <param name="email">Email</param>
+        /// <param name="password">Password</param>
+        public User(string userName,string email, string password):this()
+        {
+            UserName = userName;
+            Email = email;
+            Password = password;
+        }
+        /// <summary>
+        /// parameterless constructor
+        /// </summary>
+        public User()
+        {
+
+        }
     }
 
 }

--- a/WordPressPCL/Utility/MediaQueryBuilder.cs
+++ b/WordPressPCL/Utility/MediaQueryBuilder.cs
@@ -91,7 +91,7 @@ namespace WordPressPCL.Utility
         /// <remarks>Default:  inherit
         /// One of: inherit, private, trash</remarks>
         [QueryText("status")]
-        public MediaStatus[] Statuses { get; set; }
+        public MediaQueryStatus[] Statuses { get; set; }
         /// <summary>
         /// Use WP Query arguments to modify the response; private query vars require appropriate authorization.
         /// </summary>

--- a/WordPressPCL/Utility/MimeTypeHelper.cs
+++ b/WordPressPCL/Utility/MimeTypeHelper.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WordPressPCL.Utility
+{
+    /// <summary>
+    /// Helper class with common methods to operate with MIME Type
+    /// </summary>
+    public class MimeTypeHelper
+    {
+        /// <summary>
+        /// Get MIME type of file from extension
+        /// </summary>
+        /// <param name="extension"></param>
+        /// <returns></returns>
+        public static string GetMIMETypeFromExtension(string extension)
+        {
+            //List from https://codex.wordpress.org/Function_Reference/get_allowed_mime_types
+            switch (extension.ToLower())
+            {
+                // Image formats
+                case "jpg": case "jpeg": case"jpe": return "image/jpeg";
+                case "gif": return "image/gif";
+                case "png": return "image/png";
+                case "bmp": return "image/bmp";
+                case "tif": case"tiff": return "image/tiff";
+                case "ico": return "image/x-icon";
+
+                // Video formats
+                case "asf": case"asx": return "video/x-ms-asf";
+                case "wmv": return "video/x-ms-wmv";
+                case "wmx": return "video/x-ms-wmx";
+                case "wm": return "video/x-ms-wm";
+                case "avi": return "video/avi";
+                case "divx": return "video/divx";
+                case "flv": return "video/x-flv";
+                case "mov":case"qt": return "video/quicktime";
+                case "mpeg": case "mpg": case"mpe": return "video/mpeg";
+                case "mp4": case"m4v": return "video/mp4";
+                case "ogv": return "video/ogg";
+                case "webm": return "video/webm";
+                case "mkv": return "video/x-matroska";
+
+                // Text formats
+                case "txt": case "asc": case "c": case "cc": case "h":               return "text/plain";
+                case "csv": return "text/csv";
+                case "tsv": return "text/tab-separated-values";
+                case "ics": return "text/calendar";
+                case "rtx": return "text/richtext";
+                case "css": return "text/css";
+                case "htm": case"html": return "text/html";
+
+                // Audio formats
+                case "mp3": case "m4a": case "m4b": return "audio/mpeg";
+                case "ra": case"ram": return "audio/x-realaudio";
+                case "wav": return "audio/wav";
+                case "ogg": case"oga": return "audio/ogg";
+                case "mid": case"midi": return "audio/midi";
+                case "wma": return "audio/x-ms-wma";
+                case "wax": return "audio/x-ms-wax";
+                case "mka": return "audio/x-matroska";
+
+                // Misc application formats
+                case "rtf": return "application/rtf";
+                case "js": return "application/javascript";
+                case "pdf": return "application/pdf";
+                case "swf": return "application/x-shockwave-flash";
+                case "class": return "application/java";
+                case "tar": return "application/x-tar";
+                case "zip": return "application/zip";
+                case "gz": case"gzip": return "application/x-gzip";
+                case "rar": return "application/rar";
+                case "7z": return "application/x-7z-compressed";
+                case "exe": return "application/x-msdownload";
+
+                // MS Office formats
+                case "doc": return "application/msword";
+                case "pot": case "pps": case"ppt": return "application/vnd.ms-powerpoint";
+                case "wri": return "application/vnd.ms-write";
+                case "xla": case "xls": case "xlt": case"xlw":              return "application/vnd.ms-excel";
+                case "mdb": return "application/vnd.ms-access";
+                case "mpp": return "application/vnd.ms-project";
+                case "docx": return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+                case "docm": return "application/vnd.ms-word.document.macroEnabled.12";
+                case "dotx": return "application/vnd.openxmlformats-officedocument.wordprocessingml.template";
+                case "dotm": return "application/vnd.ms-word.template.macroEnabled.12";
+                case "xlsx": return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+                case "xlsm": return "application/vnd.ms-excel.sheet.macroEnabled.12";
+                case "xlsb": return "application/vnd.ms-excel.sheet.binary.macroEnabled.12";
+                case "xltx": return "application/vnd.openxmlformats-officedocument.spreadsheetml.template";
+                case "xltm": return "application/vnd.ms-excel.template.macroEnabled.12";
+                case "xlam": return "application/vnd.ms-excel.addin.macroEnabled.12";
+                case "pptx": return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+                case "pptm": return "application/vnd.ms-powerpoint.presentation.macroEnabled.12";
+                case "ppsx": return "application/vnd.openxmlformats-officedocument.presentationml.slideshow";
+                case "ppsm": return "application/vnd.ms-powerpoint.slideshow.macroEnabled.12";
+                case "potx": return "application/vnd.openxmlformats-officedocument.presentationml.template";
+                case "potm": return "application/vnd.ms-powerpoint.template.macroEnabled.12";
+                case "ppam": return "application/vnd.ms-powerpoint.addin.macroEnabled.12";
+                case "sldx": return "application/vnd.openxmlformats-officedocument.presentationml.slide";
+                case "sldm": return "application/vnd.ms-powerpoint.slide.macroEnabled.12";
+                case "onetoc": case "onetoc2": case "onetmp": case"onepkg": return "application/onenote";
+
+                // OpenOffice formats
+                case "odt": return "application/vnd.oasis.opendocument.text";
+                case "odp": return "application/vnd.oasis.opendocument.presentation";
+                case "ods": return "application/vnd.oasis.opendocument.spreadsheet";
+                case "odg": return "application/vnd.oasis.opendocument.graphics";
+                case "odc": return "application/vnd.oasis.opendocument.chart";
+                case "odb": return "application/vnd.oasis.opendocument.database";
+                case "odf": return "application/vnd.oasis.opendocument.formula";
+
+                // WordPerfect formats
+                case "wp": case"wpd": return "application/wordperfect";
+
+                // iWork formats
+                case "key": return "application/vnd.apple.keynote";
+                case "numbers": return "application/vnd.apple.numbers";
+                case "pages": return "application/vnd.apple.pages";
+                default: return "text/plain";
+            }
+        }
+    }
+}

--- a/WordPressPCL/WordPressPCL.csproj
+++ b/WordPressPCL/WordPressPCL.csproj
@@ -24,7 +24,7 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ValueTuple" Version="4.3.1" />
   </ItemGroup>
 </Project>

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -16,11 +16,12 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Categories.Query(WordPressPCL.Utility.CategoriesQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Categories.Query(WordPressPCL.Utility.CategoriesQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Categories query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered categories</returns>
         </member>
         <member name="M:WordPressPCL.Client.Categories.Create(WordPressPCL.Models.Category)">
@@ -44,19 +45,21 @@
             <param name="ID">Category Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Categories.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Categories.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Categories
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Categories</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Categories.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Categories.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get Category by Id
             </summary>
             <param name="ID">Category ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>Category by Id</returns>
         </member>
         <member name="T:WordPressPCL.Client.Comments">
@@ -71,11 +74,12 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Comments.Query(WordPressPCL.Utility.CommentsQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Comments.Query(WordPressPCL.Utility.CommentsQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Comments query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered comments</returns>
         </member>
         <member name="M:WordPressPCL.Client.Comments.Create(WordPressPCL.Models.Comment)">
@@ -99,27 +103,30 @@
             <param name="ID">Comment Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Comments.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Comments.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Comments
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Comments</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Comments.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Comments.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get Comment by Id
             </summary>
             <param name="ID">Comment ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>Comment by Id</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Comments.GetCommentsForPost(System.String,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Comments.GetCommentsForPost(System.String,System.Boolean,System.Boolean)">
             <summary>
             Get comments for Post
             </summary>
             <param name="PostID">Post id</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of comments for post</returns>
         </member>
         <member name="M:WordPressPCL.Client.Comments.Delete(System.Int32,System.Boolean)">
@@ -142,18 +149,27 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Media.Query(WordPressPCL.Utility.MediaQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Media.Query(WordPressPCL.Utility.MediaQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Media query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered Media</returns>
         </member>
         <member name="M:WordPressPCL.Client.Media.Create(WordPressPCL.Models.MediaItem)">
             <summary>
-            Create Media
+            Create Empty Media
             </summary>
             <param name="Entity">Media object</param>
+            <returns>Created media object</returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Media.Create(System.IO.Stream,System.String)">
+            <summary>
+            Create Media entity with attachment
+            </summary>
+            <param name="fileStream">stream with file content</param>
+            <param name="filename">Name of file in WP Media Library</param>
             <returns>Created media object</returns>
         </member>
         <member name="M:WordPressPCL.Client.Media.Update(WordPressPCL.Models.MediaItem)">
@@ -170,19 +186,21 @@
             <param name="ID">Media Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Media.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Media.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Media
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Media</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Media.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Media.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get Media by Id
             </summary>
             <param name="ID">Media ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>Media by Id</returns>
         </member>
         <member name="M:WordPressPCL.Client.Media.Delete(System.Int32,System.Boolean)">
@@ -205,11 +223,12 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Pages.Query(WordPressPCL.Utility.PagesQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Pages.Query(WordPressPCL.Utility.PagesQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Pages query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered pages</returns>
         </member>
         <member name="M:WordPressPCL.Client.Pages.Create(WordPressPCL.Models.Page)">
@@ -233,35 +252,39 @@
             <param name="ID">Page Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Pages.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Pages.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Pages
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Pages</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Pages.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Pages.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get Page by Id
             </summary>
             <param name="ID">Page ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>Page by Id</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Pages.GetPagesByAuthor(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Pages.GetPagesByAuthor(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get pages by its author
             </summary>
             <param name="authorId">Author id</param>
             <param name="embed">includ embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of pages</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Pages.GetPagesBySearch(System.String,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Pages.GetPagesBySearch(System.String,System.Boolean,System.Boolean)">
             <summary>
             Get pages by search term
             </summary>
             <param name="searchTerm">Search term</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of pages</returns>
         </member>
         <member name="M:WordPressPCL.Client.Pages.Delete(System.Int32,System.Boolean)">
@@ -284,11 +307,12 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.Query(WordPressPCL.Utility.PostsQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Posts.Query(WordPressPCL.Utility.PostsQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Posts query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered posts</returns>
         </member>
         <member name="M:WordPressPCL.Client.Posts.Create(WordPressPCL.Models.Post)">
@@ -312,58 +336,65 @@
             <param name="ID">Post Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Posts
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Posts</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get Post by Id
             </summary>
             <param name="ID">Post ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>Post by Id</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetStickyPosts(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetStickyPosts(System.Boolean,System.Boolean)">
             <summary>
             Get sticky posts
             </summary>
             <param name="embed">includ embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of posts</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetPostsByCategory(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetPostsByCategory(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get posts by category
             </summary>
             <param name="categoryId">Category Id</param>
             <param name="embed">includ embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of posts</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetPostsByTag(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetPostsByTag(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get posts by tag
             </summary>
             <param name="tagId">Tag Id</param>
             <param name="embed">includ embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of posts</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetPostsByAuthor(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetPostsByAuthor(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get posts by its author
             </summary>
             <param name="authorId">Author id</param>
             <param name="embed">includ embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of posts</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.GetPostsBySearch(System.String,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Posts.GetPostsBySearch(System.String,System.Boolean,System.Boolean)">
             <summary>
             Get posts by search term
             </summary>
             <param name="searchTerm">Search term</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of posts</returns>
         </member>
         <member name="M:WordPressPCL.Client.Posts.Delete(System.Int32,System.Boolean)">
@@ -386,11 +417,12 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Tags.Query(WordPressPCL.Utility.TagsQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Tags.Query(WordPressPCL.Utility.TagsQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Tags query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered tags</returns>
         </member>
         <member name="M:WordPressPCL.Client.Tags.Create(WordPressPCL.Models.Tag)">
@@ -414,19 +446,21 @@
             <param name="ID">Tag Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Tags.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Tags.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Tags
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Tags</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Tags.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Tags.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             Get Tag by Id
             </summary>
             <param name="ID">Tag ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>Tag by Id</returns>
         </member>
         <member name="T:WordPressPCL.Client.Users">
@@ -441,11 +475,12 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Users.Query(WordPressPCL.Utility.UsersQueryBuilder)">
+        <member name="M:WordPressPCL.Client.Users.Query(WordPressPCL.Utility.UsersQueryBuilder,System.Boolean)">
             <summary>
             Create a parametrized query and get a result
             </summary>
             <param name="queryBuilder">Users query builder with specific parameters</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of filtered users</returns>
         </member>
         <member name="M:WordPressPCL.Client.Users.Create(WordPressPCL.Models.User)">
@@ -469,19 +504,21 @@
             <param name="ID">User Id</param>
             <returns>Result of operation</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Users.GetAll(System.Boolean)">
+        <member name="M:WordPressPCL.Client.Users.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get All Users
             </summary>
             <param name="embed">Include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>List of all Users</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Users.GetByID(System.Int32,System.Boolean)">
+        <member name="M:WordPressPCL.Client.Users.GetByID(System.Int32,System.Boolean,System.Boolean)">
             <summary>
             GetUser by Id
             </summary>
             <param name="ID">User ID</param>
             <param name="embed">include embed info</param>
+            <param name="useAuth">Send request with authenication header</param>
             <returns>User by Id</returns>
         </member>
         <member name="M:WordPressPCL.Client.Users.GetCurrentUser">
@@ -574,6 +611,17 @@
             Meta fields.
             </summary>
             <remarks>Context: view, edit</remarks>
+        </member>
+        <member name="M:WordPressPCL.Models.Category.#ctor">
+            <summary>
+            Parameterless constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Category.#ctor(System.String)">
+            <summary>
+            
+            </summary>
+            <param name="name"></param>
         </member>
         <member name="T:WordPressPCL.Models.Comment">
             <summary>
@@ -691,6 +739,23 @@
             </summary>
             <remarks>Context: edit</remarks>
         </member>
+        <member name="P:WordPressPCL.Models.Comment._links">
+            <summary>
+            Links to another entities
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Comment.#ctor">
+            <summary>
+            Parameterless constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Comment.#ctor(System.Int32,System.String)">
+            <summary>
+            Constructor with required parameters
+            </summary>
+            <param name="postId">Post ID</param>
+            <param name="content">Comment content</param>
+        </member>
         <member name="T:WordPressPCL.Models.Embedded">
             <summary>
             Embedded Information
@@ -714,6 +779,11 @@
         <member name="P:WordPressPCL.Models.Embedded.WpTerm">
             <summary>
             Terms for the post (categories, tags etc.)
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Embedded.Up">
+            <summary>
+            Parent page
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.Status">
@@ -781,22 +851,22 @@
             Comment is spam
             </summary>
         </member>
-        <member name="T:WordPressPCL.Models.MediaStatus">
+        <member name="T:WordPressPCL.Models.MediaQueryStatus">
             <summary>
             Status of Media for query builder
             </summary>
         </member>
-        <member name="F:WordPressPCL.Models.MediaStatus.Inherit">
+        <member name="F:WordPressPCL.Models.MediaQueryStatus.Inherit">
             <summary>
             Media inherit
             </summary>
         </member>
-        <member name="F:WordPressPCL.Models.MediaStatus.Private">
+        <member name="F:WordPressPCL.Models.MediaQueryStatus.Private">
             <summary>
             Media is private
             </summary>
         </member>
-        <member name="F:WordPressPCL.Models.MediaStatus.Trash">
+        <member name="F:WordPressPCL.Models.MediaQueryStatus.Trash">
             <summary>
             Media is in trash
             </summary>
@@ -1189,6 +1259,36 @@
             Curries
             </summary>
         </member>
+        <member name="P:WordPressPCL.Models.Links.Author">
+            <summary>
+            Author
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.Replies">
+            <summary>
+            Replies
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.Versions">
+            <summary>
+            Versions
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.Attachment">
+            <summary>
+            Attachment
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.FeaturedMedia">
+            <summary>
+            Featured media
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.Term">
+            <summary>
+            Featured media
+            </summary>
+        </member>
         <member name="T:WordPressPCL.Models.MediaDetails">
             <summary>
             Details of media item
@@ -1380,6 +1480,11 @@
         <member name="P:WordPressPCL.Models.MediaItem.Links">
             <summary>
             Links to related resources
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.MediaItem.#ctor">
+            <summary>
+            Paremeterless constructor
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.MediaSize">
@@ -1581,6 +1686,11 @@
             Embedded information like featured images
             </summary>
         </member>
+        <member name="M:WordPressPCL.Models.Page.#ctor">
+            <summary>
+            Parameterless constructor
+            </summary>
+        </member>
         <member name="T:WordPressPCL.Models.Post">
             <summary>
             Type respresents Entity Post of WP REST API
@@ -1777,6 +1887,11 @@
         <member name="P:WordPressPCL.Models.Post.Embedded">
             <summary>
             Embedded information like featured images
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Post.#ctor">
+            <summary>
+            Parameterless constructor
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.Settings">
@@ -1984,6 +2099,24 @@
             Can the except be edited?
             </summary>
         </member>
+        <member name="M:WordPressPCL.Models.Excerpt.#ctor">
+            <summary>
+            Constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Excerpt.#ctor(System.String)">
+            <summary>
+            Constructor with same Raw and rendered Excerpt
+            </summary>
+            <param name="Excerpt">Text for Excerpt</param>
+        </member>
+        <member name="M:WordPressPCL.Models.Excerpt.#ctor(System.String,System.String)">
+            <summary>
+            Constructor with Raw and rendered text
+            </summary>
+            <param name="ExcerptRaw">Raw HTML text for Excerpt</param>
+            <param name="ExcerptRendered">Rendered text for Excerpt</param>
+        </member>
         <member name="T:WordPressPCL.Models.VersionHistory">
             <summary>
             URL to revisions
@@ -1993,6 +2126,24 @@
             <summary>
             Caption
             </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Caption.#ctor">
+            <summary>
+            Constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Caption.#ctor(System.String)">
+            <summary>
+            Constructor with the same raw and rendered Caption
+            </summary>
+            <param name="Caption">Text for caption</param>
+        </member>
+        <member name="M:WordPressPCL.Models.Caption.#ctor(System.String,System.String)">
+            <summary>
+            Constructor with raw and rendered caption
+            </summary>
+            <param name="CaptionRaw">Raw text for caption</param>
+            <param name="CaptionRendered">Rendered text for caption</param>
         </member>
         <member name="T:WordPressPCL.Models.HttpsApiWOrgFeaturedmedia">
             <summary>
@@ -2115,6 +2266,17 @@
             </summary>
             <remarks>Context: view</remarks>
         </member>
+        <member name="M:WordPressPCL.Models.Tag.#ctor">
+            <summary>
+            Parameterless constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Tag.#ctor(System.String)">
+            <summary>
+            Constructor with required parameters
+            </summary>
+            <param name="name">Tag name</param>
+        </member>
         <member name="T:WordPressPCL.Models.Term">
             <summary>
             This is the base class for all terms, like categories and tags
@@ -2163,6 +2325,11 @@
         <member name="P:WordPressPCL.Models.Term.Links">
             <summary>
             Links to related resources
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Term.#ctor">
+            <summary>
+            parameterless constructor
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.User">
@@ -2298,6 +2465,19 @@
         <member name="P:WordPressPCL.Models.User.Links">
             <summary>
             Links to related resources
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.User.#ctor(System.String,System.String,System.String)">
+            <summary>
+            Constructor with required parameters
+            </summary>
+            <param name="userName">Username</param>
+            <param name="email">Email</param>
+            <param name="password">Password</param>
+        </member>
+        <member name="M:WordPressPCL.Models.User.#ctor">
+            <summary>
+            parameterless constructor
             </summary>
         </member>
         <member name="T:WordPressPCL.Utility.CategoriesQueryBuilder">
@@ -2587,6 +2767,18 @@
             <summary>
             Limit result set to attachments of a particular MIME type.
             </summary>
+        </member>
+        <member name="T:WordPressPCL.Utility.MimeTypeHelper">
+            <summary>
+            Helper class with common methods to operate with MIME Type
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Utility.MimeTypeHelper.GetMIMETypeFromExtension(System.String)">
+            <summary>
+            Get MIME type of file from extension
+            </summary>
+            <param name="extension"></param>
+            <returns></returns>
         </member>
         <member name="T:WordPressPCL.Utility.PagesQueryBuilder">
             <summary>

--- a/WordPressPCLTests/Categories_Tests.cs
+++ b/WordPressPCLTests/Categories_Tests.cs
@@ -17,7 +17,14 @@ namespace WordPressPCLTests
         [TestMethod]
         public async Task Categories_Create()
         {
-            Assert.Inconclusive();
+            var client = await ClientHelper.GetAuthenticatedWordPressClient();
+            var category = await client.Categories.Create(new Category()
+            {
+                Name = "Test",
+                Description = "Test"
+            });
+            Assert.IsNotNull(category);
+            Assert.AreEqual("Test", category.Name);
         }
         [TestMethod]
         public async Task Categories_Read()

--- a/WordPressPCLTests/Media_Tests.cs
+++ b/WordPressPCLTests/Media_Tests.cs
@@ -8,16 +8,21 @@ using WordPressPCLTests.Utility;
 using System.Linq;
 using WordPressPCL.Utility;
 using WordPressPCL.Models;
+using System.IO;
 
 namespace WordPressPCLTests
 {
     [TestClass]
     public class Media_Tests
     {
+        
         [TestMethod]
         public async Task Media_Create()
         {
-            Assert.Inconclusive();
+            var client = await ClientHelper.GetAuthenticatedWordPressClient();
+            Stream s = File.OpenRead(@"1.jpg");
+            var mediaitem = await client.Media.Create(s,"1.jpg");
+            Assert.IsNotNull(mediaitem);
         }
         [TestMethod]
         public async Task Media_Read()

--- a/WordPressPCLTests/Pages_Tests.cs
+++ b/WordPressPCLTests/Pages_Tests.cs
@@ -83,10 +83,11 @@ namespace WordPressPCLTests
                 PerPage = 15,
                 OrderBy = PagesOrderBy.Title,
                 Order = Order.DESC,
-                Statuses = new Status[] { Status.Publish }
+                Statuses = new Status[] { Status.Publish },
+                Embed=true
             };
             var queryresult = await client.Pages.Query(queryBuilder);
-            Assert.AreEqual(queryBuilder.BuildQueryURL(), "?page=1&per_page=15&orderby=title&status=publish&order=desc");
+            Assert.AreEqual(queryBuilder.BuildQueryURL(), "?page=1&per_page=15&orderby=title&status=publish&order=desc&_embed=true");
             Assert.IsNotNull(queryresult);
             Assert.AreNotSame(queryresult.Count(), 0);
         }

--- a/WordPressPCLTests/Posts_Tests.cs
+++ b/WordPressPCLTests/Posts_Tests.cs
@@ -83,10 +83,11 @@ namespace WordPressPCLTests
                 PerPage = 15,
                 OrderBy = PostsOrderBy.Title,
                 Order = Order.DESC,
-                Statuses = new Status[] { Status.Publish }
+                Statuses = new Status[] { Status.Publish },
+                Embed = true
             };
             var queryresult = await client.Posts.Query(queryBuilder);
-            Assert.AreEqual(queryBuilder.BuildQueryURL(), "?page=1&per_page=15&orderby=title&status=publish&order=desc");
+            Assert.AreEqual(queryBuilder.BuildQueryURL(), "?page=1&per_page=15&orderby=title&status=publish&order=desc&_embed=true");
             Assert.IsNotNull(queryresult);
             Assert.AreNotSame(queryresult.Count(), 0);
         }

--- a/WordPressPCLTests/Tag_Tests.cs
+++ b/WordPressPCLTests/Tag_Tests.cs
@@ -17,7 +17,14 @@ namespace WordPressPCLTests
         [TestMethod]
         public async Task Tags_Create()
         {
-            Assert.Inconclusive();
+            var client = await ClientHelper.GetAuthenticatedWordPressClient();
+            var tag = await client.Tags.Create(new Tag()
+            {
+                Name = "Test",
+                Description = "Test"
+            });
+            Assert.IsNotNull(tag);
+            Assert.AreEqual("Test", tag.Name);
         }
         [TestMethod]
         public async Task Tags_Read()

--- a/WordPressPCLTests/User_Tests.cs
+++ b/WordPressPCLTests/User_Tests.cs
@@ -17,7 +17,22 @@ namespace WordPressPCLTests
         [TestMethod]
         public async Task Users_Create()
         {
-            Assert.Inconclusive();
+            var client = await ClientHelper.GetAuthenticatedWordPressClient();
+            var user = await client.Users.Create(new User("test","test@mail.ru","test")
+            {
+                NickName = "test",
+                Name = "test",
+                FirstName = "First",
+                LastName = "Last"
+            });
+            Assert.IsNotNull(user);
+            Assert.AreEqual("test", user.NickName);
+            Assert.AreEqual("test", user.Name);
+            Assert.AreEqual("First", user.FirstName);
+            Assert.AreEqual("Last", user.LastName);
+            Assert.AreEqual("test", user.UserName);
+            Assert.AreEqual("test@test.test", user.Email);
+
         }
         [TestMethod]
         public async Task Users_Read()

--- a/WordPressPCLTests/User_Tests.cs
+++ b/WordPressPCLTests/User_Tests.cs
@@ -18,7 +18,7 @@ namespace WordPressPCLTests
         public async Task Users_Create()
         {
             var client = await ClientHelper.GetAuthenticatedWordPressClient();
-            var user = await client.Users.Create(new User("test","test@mail.ru","test")
+            var user = await client.Users.Create(new User("test", "test@test.test", "test")
             {
                 NickName = "test",
                 Name = "test",


### PR DESCRIPTION
- Add some constructors with required parameters #31 
- Add implementation of Create media method (use Stream) #30 
- Throw InvalidOperationException on default Media Create (!IMPORTANT) cause we cannot create media from JSON object 
- add some tests (in my working site most of them pass!)
- fix some errors 
- add helper class to work with mime type (need for Media Create) 
- add useAuth param to Get methods (GetllAll users method require authentication) 
- extend support of links and embedding

Comments:
- I dont know what to do with Create(MediaItem), cause we cant create empty media item without attachment. For this purposes I create method Create(Stream,string)
- Post endpoint require one of three this parameters: title, content, excerpt. I dont know which parameter is more relevant for us and dont create constrcutor for Post type