### PR TITLE
JsonSerializationSettings and ToThreaded comments

### DIFF
--- a/WordPressPCL/Client/CRUDOperation.cs
+++ b/WordPressPCL/Client/CRUDOperation.cs
@@ -59,7 +59,8 @@ namespace WordPressPCL.Client
         /// <returns>Created object</returns>
         public async Task<TClass> Create(TClass Entity)
         {
-            var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            var entity = _httpHelper.JsonSerializerSettings==null ? JsonConvert.SerializeObject(Entity) : JsonConvert.SerializeObject(Entity,_httpHelper.JsonSerializerSettings);
+            var postBody = new StringContent(entity, Encoding.UTF8, "application/json");
             return (await _httpHelper.PostRequest<TClass>($"{_defaultPath}{_methodPath}", postBody)).Item1;
         }
 
@@ -135,7 +136,8 @@ namespace WordPressPCL.Client
         /// <returns>Updated object</returns>
         public async Task<TClass> Update(TClass Entity)
         {
-            var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            var entity = _httpHelper.JsonSerializerSettings == null ? JsonConvert.SerializeObject(Entity) : JsonConvert.SerializeObject(Entity, _httpHelper.JsonSerializerSettings);
+            var postBody = new StringContent(entity, Encoding.UTF8, "application/json");
             return (await _httpHelper.PostRequest<TClass>($"{_defaultPath}{_methodPath}/{(Entity as Base).Id}", postBody)).Item1;
         }
     }

--- a/WordPressPCL/Client/CustomRequest.cs
+++ b/WordPressPCL/Client/CustomRequest.cs
@@ -32,7 +32,8 @@ namespace WordPressPCL.Client
         /// <returns>Created object</returns>
         public async Task<TOutput> Create<TInput, TOutput>(string route, TInput Entity) where TOutput : class
         {
-            StringContent sc = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            var entity = _httpHelper.JsonSerializerSettings == null ? JsonConvert.SerializeObject(Entity) : JsonConvert.SerializeObject(Entity, _httpHelper.JsonSerializerSettings);
+            StringContent sc = new StringContent(entity, Encoding.UTF8, "application/json");
             return (await _httpHelper.PostRequest<TOutput>($"{route}", sc)).Item1;
         }
 

--- a/WordPressPCL/Client/Media.cs
+++ b/WordPressPCL/Client/Media.cs
@@ -146,7 +146,8 @@ namespace WordPressPCL.Client
         /// <returns>Updated object</returns>
         public async Task<MediaItem> Update(MediaItem Entity)
         {
-            var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            var entity = _httpHelper.JsonSerializerSettings == null ? JsonConvert.SerializeObject(Entity) : JsonConvert.SerializeObject(Entity, _httpHelper.JsonSerializerSettings);
+            var postBody = new StringContent(entity, Encoding.UTF8, "application/json");
             return (await _httpHelper.PostRequest<MediaItem>($"{_defaultPath}{_methodPath}/{(Entity as Base).Id}", postBody)).Item1;
         }
     }

--- a/WordPressPCL/Client/Users.cs
+++ b/WordPressPCL/Client/Users.cs
@@ -41,7 +41,8 @@ namespace WordPressPCL.Client
         /// <returns>Created object</returns>
         public virtual async Task<User> Create(User Entity)
         {
-            var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            var entity = _httpHelper.JsonSerializerSettings == null ? JsonConvert.SerializeObject(Entity) : JsonConvert.SerializeObject(Entity, _httpHelper.JsonSerializerSettings);
+            var postBody = new StringContent(entity, Encoding.UTF8, "application/json");
             return (await _httpHelper.PostRequest<User>($"{_defaultPath}{_methodPath}", postBody)).Item1;
         }
 
@@ -107,7 +108,8 @@ namespace WordPressPCL.Client
         /// <returns>Updated object</returns>
         public async Task<User> Update(User Entity)
         {
-            var postBody = new StringContent(JsonConvert.SerializeObject(Entity).ToString(), Encoding.UTF8, "application/json");
+            var entity = _httpHelper.JsonSerializerSettings == null ? JsonConvert.SerializeObject(Entity) : JsonConvert.SerializeObject(Entity, _httpHelper.JsonSerializerSettings);
+            var postBody = new StringContent(entity, Encoding.UTF8, "application/json");
             return (await _httpHelper.PostRequest<User>($"{_defaultPath}{_methodPath}/{(Entity as Base).Id}", postBody)).Item1;
         }
 

--- a/WordPressPCL/Utility/DateTimeFormatHelper.cs
+++ b/WordPressPCL/Utility/DateTimeFormatHelper.cs
@@ -1,0 +1,68 @@
+﻿using Newtonsoft.Json;
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace WordPressPCL.Utility
+{
+    /*
+    /// <summary>
+    /// Helper class with some usefull functions to operate with date time format settings
+    /// </summary>
+    public static class DateTimeFormatHelper
+    {
+        /// <summary>
+        /// BETA. Use it only for nonstandard WordPress datetime.
+        /// Function tries to convert your PHP WP datetime format  into Microsoft datettime format for serialization/deserialization
+        /// Works only with auth
+        /// </summary>
+        /// <param name="client">current WordPress client instance</param>
+        /// <param name="cultureInfo">Your site culture info</param>
+        public static async Task AutoConfigureDateSerialization(this WordPressClient client, CultureInfo cultureInfo)
+        {
+            if (await client.IsValidJWToken())
+            {
+                var settings = await client.GetSettings();
+                var netdateformat = ParsePHPDateTimeFormat(settings.DateFormat, settings.TimeFormat);
+                if (client.JsonSerializerSettings == null)
+                {
+                    client.JsonSerializerSettings = new JsonSerializerSettings() { DateFormatString = netdateformat, Culture = cultureInfo };
+                }
+                else
+                {
+                    client.JsonSerializerSettings.DateFormatString = netdateformat;
+                }
+            }
+        }
+
+        private static string ParsePHPDateTimeFormat(string dateFormat, string timeFormat)
+        {
+            //http://php.net/manual/ru/function.date.php
+            //https://msdn.microsoft.com/ru-ru/library/8kb3ddd4(v=vs.110).aspx
+            string result = dateFormat.Replace("d", "dd")
+                                      .Replace("D", "ddd")
+                                      .Replace("j", "d")
+                                      .Replace("l", "dddd")
+                                      .Replace("M", "MMM")
+                                      .Replace("F", "MMMM")
+                                      .Replace("m", "MM")
+                                      .Replace("n", "M")
+                                      .Replace("o", "yyyy")
+                                      .Replace("y", "yy")
+                                      .Replace("Y", "yyyy") + " " +
+                                      timeFormat.Replace("a", "tt")
+                                              .Replace("A", "tt")
+                                              .Replace("g", "h")
+                                              .Replace("G", "H")
+                                              .Replace("h", "чч")
+                                              .Replace("H", "HH")
+                                              .Replace("i", "mm")
+                                              .Replace("s", "сс")
+                                              .Replace("u", "FFFFFF")
+                                              .Replace("v", "FFF")
+                                              .Replace("e", "K")
+                                              .Replace("O", "zz")
+                                              .Replace("P", "zzz");
+            return result;
+        }
+    }*/
+}

--- a/WordPressPCL/Utility/HttpHelper.cs
+++ b/WordPressPCL/Utility/HttpHelper.cs
@@ -26,6 +26,11 @@ namespace WordPressPCL.Utility
         /// </summary>
         public Func<string, string> HttpResponsePreProcessing { get; set; }
         /// <summary>
+        /// Serialization/Deserialization settings for Json.NET library
+        /// https://www.newtonsoft.com/json/help/html/SerializationSettings.htm
+        /// </summary>
+        public JsonSerializerSettings JsonSerializerSettings { get; set; }
+        /// <summary>
         /// Constructor
         /// <paramref name="WordpressURI"/>
         /// </summary>
@@ -62,7 +67,8 @@ namespace WordPressPCL.Utility
                     {
                         if (HttpResponsePreProcessing != null)
                             responseString = HttpResponsePreProcessing(responseString);
-
+                        if (JsonSerializerSettings != null)
+                            return JsonConvert.DeserializeObject<TClass>(responseString, JsonSerializerSettings);
                         return JsonConvert.DeserializeObject<TClass>(responseString);
                     }
                     else
@@ -99,7 +105,8 @@ namespace WordPressPCL.Utility
                     {
                         if (HttpResponsePreProcessing != null)
                             responseString = HttpResponsePreProcessing(responseString);
-
+                        if (JsonSerializerSettings != null)
+                            return (JsonConvert.DeserializeObject<TClass>(responseString, JsonSerializerSettings), response);
                         return (JsonConvert.DeserializeObject<TClass>(responseString), response);
                     }
                     else

--- a/WordPressPCL/Utility/MimeTypeHelper.cs
+++ b/WordPressPCL/Utility/MimeTypeHelper.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace WordPressPCL.Utility
+﻿namespace WordPressPCL.Utility
 {
     /// <summary>
     /// Helper class with common methods to operate with MIME Type
@@ -20,43 +16,43 @@ namespace WordPressPCL.Utility
             switch (extension.ToLower())
             {
                 // Image formats
-                case "jpg": case "jpeg": case"jpe": return "image/jpeg";
+                case "jpg": case "jpeg": case "jpe": return "image/jpeg";
                 case "gif": return "image/gif";
                 case "png": return "image/png";
                 case "bmp": return "image/bmp";
-                case "tif": case"tiff": return "image/tiff";
+                case "tif": case "tiff": return "image/tiff";
                 case "ico": return "image/x-icon";
 
                 // Video formats
-                case "asf": case"asx": return "video/x-ms-asf";
+                case "asf": case "asx": return "video/x-ms-asf";
                 case "wmv": return "video/x-ms-wmv";
                 case "wmx": return "video/x-ms-wmx";
                 case "wm": return "video/x-ms-wm";
                 case "avi": return "video/avi";
                 case "divx": return "video/divx";
                 case "flv": return "video/x-flv";
-                case "mov":case"qt": return "video/quicktime";
-                case "mpeg": case "mpg": case"mpe": return "video/mpeg";
-                case "mp4": case"m4v": return "video/mp4";
+                case "mov": case "qt": return "video/quicktime";
+                case "mpeg": case "mpg": case "mpe": return "video/mpeg";
+                case "mp4": case "m4v": return "video/mp4";
                 case "ogv": return "video/ogg";
                 case "webm": return "video/webm";
                 case "mkv": return "video/x-matroska";
 
                 // Text formats
-                case "txt": case "asc": case "c": case "cc": case "h":               return "text/plain";
+                case "txt": case "asc": case "c": case "cc": case "h": return "text/plain";
                 case "csv": return "text/csv";
                 case "tsv": return "text/tab-separated-values";
                 case "ics": return "text/calendar";
                 case "rtx": return "text/richtext";
                 case "css": return "text/css";
-                case "htm": case"html": return "text/html";
+                case "htm": case "html": return "text/html";
 
                 // Audio formats
                 case "mp3": case "m4a": case "m4b": return "audio/mpeg";
-                case "ra": case"ram": return "audio/x-realaudio";
+                case "ra": case "ram": return "audio/x-realaudio";
                 case "wav": return "audio/wav";
-                case "ogg": case"oga": return "audio/ogg";
-                case "mid": case"midi": return "audio/midi";
+                case "ogg": case "oga": return "audio/ogg";
+                case "mid": case "midi": return "audio/midi";
                 case "wma": return "audio/x-ms-wma";
                 case "wax": return "audio/x-ms-wax";
                 case "mka": return "audio/x-matroska";
@@ -69,16 +65,16 @@ namespace WordPressPCL.Utility
                 case "class": return "application/java";
                 case "tar": return "application/x-tar";
                 case "zip": return "application/zip";
-                case "gz": case"gzip": return "application/x-gzip";
+                case "gz": case "gzip": return "application/x-gzip";
                 case "rar": return "application/rar";
                 case "7z": return "application/x-7z-compressed";
                 case "exe": return "application/x-msdownload";
 
                 // MS Office formats
                 case "doc": return "application/msword";
-                case "pot": case "pps": case"ppt": return "application/vnd.ms-powerpoint";
+                case "pot": case "pps": case "ppt": return "application/vnd.ms-powerpoint";
                 case "wri": return "application/vnd.ms-write";
-                case "xla": case "xls": case "xlt": case"xlw":              return "application/vnd.ms-excel";
+                case "xla": case "xls": case "xlt": case "xlw": return "application/vnd.ms-excel";
                 case "mdb": return "application/vnd.ms-access";
                 case "mpp": return "application/vnd.ms-project";
                 case "docx": return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
@@ -100,7 +96,7 @@ namespace WordPressPCL.Utility
                 case "ppam": return "application/vnd.ms-powerpoint.addin.macroEnabled.12";
                 case "sldx": return "application/vnd.openxmlformats-officedocument.presentationml.slide";
                 case "sldm": return "application/vnd.ms-powerpoint.slide.macroEnabled.12";
-                case "onetoc": case "onetoc2": case "onetmp": case"onepkg": return "application/onenote";
+                case "onetoc": case "onetoc2": case "onetmp": case "onepkg": return "application/onenote";
 
                 // OpenOffice formats
                 case "odt": return "application/vnd.oasis.opendocument.text";
@@ -112,7 +108,7 @@ namespace WordPressPCL.Utility
                 case "odf": return "application/vnd.oasis.opendocument.formula";
 
                 // WordPerfect formats
-                case "wp": case"wpd": return "application/wordperfect";
+                case "wp": case "wpd": return "application/wordperfect";
 
                 // iWork formats
                 case "key": return "application/vnd.apple.keynote";

--- a/WordPressPCL/Utility/QueryBuilder.cs
+++ b/WordPressPCL/Utility/QueryBuilder.cs
@@ -71,8 +71,7 @@ namespace WordPressPCL.Utility
         private object GetPropertyValue(object property)
         {
             //secion for propertyInfo object
-            PropertyInfo pi = property as PropertyInfo;
-            if (pi != null)
+            if (property is PropertyInfo pi)
             {
                 if (pi.PropertyType.GetTypeInfo().IsEnum)
                 {

--- a/WordPressPCL/Utility/ThreadedCommentsHelper.cs
+++ b/WordPressPCL/Utility/ThreadedCommentsHelper.cs
@@ -109,5 +109,14 @@ namespace WordPressPCL.Utility
 
             }
         }
+        /// <summary>
+        /// Extension method: Get Threaded comments from ordinary comments
+        /// </summary>
+        /// <param name="comments">Comments which will be threaded</param>
+        /// <returns>List of threaded comments</returns>
+        public static List<CommentThreaded> ToThreaded(this IEnumerable<Comment> comments)
+        {
+            return GetThreadedComments(comments);
+        }
     }
 }

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -136,6 +136,10 @@ namespace WordPressPCL
             {
                 uri += "/";
             }
+            if (!uri.EndsWith("wp-json/"))
+            {
+                uri += "wp-json/";
+            }
 
             _wordPressUri = uri;
             _httpHelper = new HttpHelper(WordPressUri);

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -43,6 +43,7 @@ namespace WordPressPCL
                 _httpHelper.HttpResponsePreProcessing = value;
             }
         }
+
         /// <summary>
         /// Serialization/Deserialization settings for Json.NET library
         /// https://www.newtonsoft.com/json/help/html/SerializationSettings.htm
@@ -58,6 +59,7 @@ namespace WordPressPCL
                 return _httpHelper.JsonSerializerSettings;
             }
         }
+
         /// <summary>
         /// Authentication method
         /// </summary>

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -43,7 +43,21 @@ namespace WordPressPCL
                 _httpHelper.HttpResponsePreProcessing = value;
             }
         }
-
+        /// <summary>
+        /// Serialization/Deserialization settings for Json.NET library
+        /// https://www.newtonsoft.com/json/help/html/SerializationSettings.htm
+        /// </summary>
+        public JsonSerializerSettings JsonSerializerSettings
+        {
+            set
+            {
+                _httpHelper.JsonSerializerSettings = value;
+            }
+            get
+            {
+                return _httpHelper.JsonSerializerSettings;
+            }
+        }
         /// <summary>
         /// Authentication method
         /// </summary>
@@ -197,11 +211,8 @@ namespace WordPressPCL
         public async Task<bool> IsValidJWToken()
         {
             var route = $"{jwtPath}token/validate";
-            using (var client = new HttpClient())
-            {
-                (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true);
-                return repsonse.IsSuccessStatusCode;
-            }
+            (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true);
+            return repsonse.IsSuccessStatusCode;
         }
 
         /// <summary>

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -212,14 +212,6 @@
             <param name="filename">Name of file in WP Media Library</param>
             <returns>Created media object</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Media.Create(System.String,System.String)">
-            <summary>
-            Create Media entity with attachment
-            </summary>
-            <param name="filePath">Local Path to file</param>
-            <param name="filename">Name of file in WP Media Library</param>
-            <returns>Created media object</returns>
-        </member>
         <member name="M:WordPressPCL.Client.Media.Delete(System.Int32)">
             <summary>
             Delete Entity
@@ -1746,6 +1738,18 @@
             <summary>
             Info about Media Size
             <see cref="P:WordPressPCL.Models.MediaDetails.Sizes"/>
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.MediaSize.File">
+            <summary>
+            File
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.MediaSize.Width">
+            <summary>
+            Media Width
+            </summary>
+        </       <see cref="P:WordPressPCL.Models.MediaDetails.Sizes"/>
             </summary>
         </member>
         <member name="P:WordPressPCL.Models.MediaSize.File">
@@ -3372,16 +3376,7 @@
         <member name="P:WordPressPCL.Utility.PagesQueryBuilder.OrderBy">
             <summary>
             Sort collection by object attribute.
-            </summary>
-            <remarks>Default: date
-            One of: date, relevance, id, include, title, slug, menu_order</remarks>
-        </member>
-        <member name="P:WordPressPCL.Utility.PagesQueryBuilder.Parents">
-            <summary>
-            Limit result set to those of particular parent ids.
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Utility.PagesQueryBuilder.ParentsExclude">
+            </summagesQueryBuilder.ParentsExclude">
             <summary>
             Limit result set to all items except those of a particular parent id.
             </summary>
@@ -3634,6 +3629,13 @@
             inlcuding the depth of a comment
             </summary>
         </member>
+        <member name="M:WordPressPCL.Utility.ThreadedCommentsHelper.ToThreaded(System.Collections.Generic.IEnumerable{WordPressPCL.Models.Comment})">
+            <summary>
+            Extension method: Get Threaded comments from ordinary comments
+            </summary>
+            <param name="comments">Comments which will be threaded</param>
+            <returns>List of threaded comments</returns>
+        </member>
         <member name="T:WordPressPCL.Utility.UsersQueryBuilder">
             <summary>
             Users Query Builder class to construct queries with valid parameters
@@ -3808,6 +3810,20 @@
             <returns>Result of checking</returns>
         </member>
         <member name="M:WordPressPCL.WordPressClient.SetJWToken(System.String)">
+            <summary>
+            Sets an exisitng JWToken
+            </summary>
+            <param name="token"></param>
+        </member>
+        <member name="M:WordPressPCL.WordPressClient.GetToken">
+            <summary>
+            Gets the JWToken from the client
+            </summary>
+            <returns></returns>
+        </member>
+    </members>
+</doc>
+ystem.String)">
             <summary>
             Sets an exisitng JWToken
             </summary>

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -212,6 +212,14 @@
             <param name="filename">Name of file in WP Media Library</param>
             <returns>Created media object</returns>
         </member>
+        <member name="M:WordPressPCL.Client.Media.Create(System.String,System.String)">
+            <summary>
+            Create Media entity with attachment
+            </summary>
+            <param name="filePath">Local Path to file</param>
+            <param name="filename">Name of file in WP Media Library</param>
+            <returns>Created media object</returns>
+        </member>
         <member name="M:WordPressPCL.Client.Media.Delete(System.Int32)">
             <summary>
             Delete Entity
@@ -1153,17 +1161,6 @@
             Sort terms collection by object attribute.
             </summary>
             <remarks>Default: name</remarks>
-        </mem        </member>
-        <member name="F:WordPressPCL.Models.UsersOrderBy.Url">
-            <summary>
-            Order By url
-            </summary>
-        </member>
-        <member name="T:WordPressPCL.Models.TermsOrderBy">
-            <summary>
-            Sort terms collection by object attribute.
-            </summary>
-            <remarks>Default: name</remarks>
         </member>
         <member name="F:WordPressPCL.Models.TermsOrderBy.Name">
             <summary>
@@ -1531,7 +1528,21 @@
             </summary>
         </member>
         <member name="P:WordPressPCL.Models.Links.Replies">
-          name="P:WordPressPCL.Models.Links.FeaturedMedia">
+            <summary>
+            Replies
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.Versions">
+            <summary>
+            Versions
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.Attachment">
+            <summary>
+            Attachment
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Links.FeaturedMedia">
             <summary>
             Featured media
             </summary>
@@ -2634,18 +2645,6 @@
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.Reply">
-            <summ        </member>
-        <member name="T:WordPressPCL.Models.Author">
-            <summary>
-            Author link
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Models.Author.Embeddable">
-            <summary>
-            Have embedded info
-            </summary>
-        </member>
-        <member name="T:WordPressPCL.Models.Reply">
             <summary>
             Link to reply
             </summary>
@@ -3182,6 +3181,12 @@
             Executed before trying to convert json content to a TClass object.
             </summary>
         </member>
+        <member name="P:WordPressPCL.Utility.HttpHelper.JsonSerializerSettings">
+            <summary>
+            Serialization/Deserialization settings for Json.NET library
+            https://www.newtonsoft.com/json/help/html/SerializationSettings.htm
+            </summary>
+        </member>
         <member name="M:WordPressPCL.Utility.HttpHelper.#ctor(System.String)">
             <summary>
             Constructor
@@ -3697,6 +3702,12 @@
             <summary>
             Function called when a HttpRequest response to WordPress APIs are readed
             Executed before trying to convert json content to a TClass object.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.WordPressClient.JsonSerializerSettings">
+            <summary>
+            Serialization/Deserialization settings for Json.NET library
+            https://www.newtonsoft.com/json/help/html/SerializationSettings.htm
             </summary>
         </member>
         <member name="P:WordPressPCL.WordPressClient.AuthMethod">

--- a/WordPressPCLTests/Basic_Tests.cs
+++ b/WordPressPCLTests/Basic_Tests.cs
@@ -4,6 +4,7 @@ using WordPressPCLTests.Utility;
 using WordPressPCL;
 using System.Threading.Tasks;
 using WordPressPCL.Models;
+using WordPressPCL.Utility;
 using System.Net;
 using System.Linq;
 

--- a/WordPressPCLTests/CommentsThreaded_Tests.cs
+++ b/WordPressPCLTests/CommentsThreaded_Tests.cs
@@ -1,24 +1,29 @@
-﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using WordPressPCLTests.Utility;
-using WordPressPCL;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Diagnostics;
 using System.Threading.Tasks;
+using WordPressPCL;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;
-using System.Net;
-using System.Linq;
-using Newtonsoft.Json;
-using System.Diagnostics;
+using WordPressPCLTests.Utility;
 
 namespace WordPressPCLTests
 {
     [TestClass]
     public class CommentsThreaded_Tests
     {
-        [TestMethod]
-        public async Task CommentsThreaded_Sort()
+        private int postid;
+        private int comment0id;
+        private int comment00id;
+        private int comment1id;
+        private int comment2id;
+        private int comment3id;
+        private int comment4id;
+        private WordPressClient client;
+
+        [ClassInitialize]
+        public async Task CommentsThreaded_SetupAsync()
         {
-            var client = await ClientHelper.GetAuthenticatedWordPressClient();
+            client = await ClientHelper.GetAuthenticatedWordPressClient();
             var IsValidToken = await client.IsValidJWToken();
             Assert.IsTrue(IsValidToken);
 
@@ -64,29 +69,40 @@ namespace WordPressPCLTests
                 ParentId = comment1.Id,
                 Content = new Content("t ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum do")
             });
+            postid = post.Id;
+            comment0id = comment0.Id;
+            comment00id = comment00.Id;
+            comment1id = comment1.Id;
+            comment2id = comment2.Id;
+            comment3id = comment3.Id;
+            comment4id = comment4.Id;
+        }
 
-            var allComments = await client.Comments.GetAllCommentsForPost(post.Id);
+        [TestMethod]
+        public async Task CommentsThreaded_Sort()
+        {
+            var allComments = await client.Comments.GetAllCommentsForPost(postid);
 
             var threaded = ThreadedCommentsHelper.GetThreadedComments(allComments);
             Debug.WriteLine($"threaded count: {threaded.Count}");
             Assert.IsNotNull(threaded);
-            var ct0 = threaded.Find(x => x.Id == comment0.Id);
+            var ct0 = threaded.Find(x => x.Id == comment0id);
             Assert.AreEqual(ct0.Depth, 0);
             Debug.WriteLine(threaded.IndexOf(ct0));
-            var ct1 = threaded.Find(x => x.Id == comment1.Id);
+            var ct1 = threaded.Find(x => x.Id == comment1id);
             Assert.AreEqual(ct1.Depth, 1);
             Debug.WriteLine(threaded.IndexOf(ct1));
-            var ct2 = threaded.Find(x => x.Id == comment2.Id);
+            var ct2 = threaded.Find(x => x.Id == comment2id);
             Assert.AreEqual(ct2.Depth, 2);
             Debug.WriteLine(threaded.IndexOf(ct2));
-            var ct3 = threaded.Find(x => x.Id == comment3.Id);
+            var ct3 = threaded.Find(x => x.Id == comment3id);
             Assert.AreEqual(ct3.Depth, 3);
             Debug.WriteLine(threaded.IndexOf(ct3));
-            var ct4 = threaded.Find(x => x.Id == comment4.Id);
+            var ct4 = threaded.Find(x => x.Id == comment4id);
             Assert.AreEqual(ct4.Depth, 2);
             Debug.WriteLine(threaded.IndexOf(ct4));
 
-            var ct00 = threaded.Find(x => x.Id == comment00.Id);
+            var ct00 = threaded.Find(x => x.Id == comment00id);
             Assert.AreEqual(ct00.Depth, 0);
             //Assert.AreEqual(threaded.Count, threaded.IndexOf(ct00) + 1);
 
@@ -102,16 +118,62 @@ namespace WordPressPCLTests
                 var idate = threaded[i].Date;
                 var nidate = threaded[ni].Date;
 
-                // The following comment date has to be newer or older with a lower depth 
+                // The following comment date has to be newer or older with a lower depth
                 var validDate = (idate <= nidate || (idate > nidate && id > nid));
                 Assert.IsTrue(validDate);
             }
-
-            // cleanup
-            await client.Posts.Delete(post.Id);
         }
 
+        [TestMethod]
+        public async Task CommentsThreaded_Sort_Extension()
+        {
+            var allComments = await client.Comments.GetAllCommentsForPost(postid);
+            //ExtensionMethod
+            var threaded = ThreadedCommentsHelper.ToThreaded(allComments);
+            Debug.WriteLine($"threaded count: {threaded.Count}");
+            Assert.IsNotNull(threaded);
+            var ct0 = threaded.Find(x => x.Id == comment0id);
+            Assert.AreEqual(ct0.Depth, 0);
+            Debug.WriteLine(threaded.IndexOf(ct0));
+            var ct1 = threaded.Find(x => x.Id == comment1id);
+            Assert.AreEqual(ct1.Depth, 1);
+            Debug.WriteLine(threaded.IndexOf(ct1));
+            var ct2 = threaded.Find(x => x.Id == comment2id);
+            Assert.AreEqual(ct2.Depth, 2);
+            Debug.WriteLine(threaded.IndexOf(ct2));
+            var ct3 = threaded.Find(x => x.Id == comment3id);
+            Assert.AreEqual(ct3.Depth, 3);
+            Debug.WriteLine(threaded.IndexOf(ct3));
+            var ct4 = threaded.Find(x => x.Id == comment4id);
+            Assert.AreEqual(ct4.Depth, 2);
+            Debug.WriteLine(threaded.IndexOf(ct4));
 
+            var ct00 = threaded.Find(x => x.Id == comment00id);
+            Assert.AreEqual(ct00.Depth, 0);
+            //Assert.AreEqual(threaded.Count, threaded.IndexOf(ct00) + 1);
+
+            for (int i = 0; i < threaded.Count - 1; i++)
+            {
+                // The following comment depth has to be the lower, equal or +1
+                var ni = i + 1;
+                var id = threaded[i].Depth;
+                var nid = threaded[ni].Depth;
+                var validDepth = (id >= nid || id + 1 == nid);
+                Assert.IsTrue(validDepth);
+
+                var idate = threaded[i].Date;
+                var nidate = threaded[ni].Date;
+
+                // The following comment date has to be newer or older with a lower depth
+                var validDate = (idate <= nidate || (idate > nidate && id > nid));
+                Assert.IsTrue(validDate);
+            }
+        }
+
+        [ClassCleanup]
+        public async void CommentsThreaded_Cleanup()
+        {
+            await client.Posts.Delete(postid);
+        }
     }
-
 }

--- a/WordPressPCLTests/Utility/ClientHelper.cs
+++ b/WordPressPCLTests/Utility/ClientHelper.cs
@@ -8,10 +8,12 @@ namespace WordPressPCLTests.Utility
     {
         public static async Task<WordPressClient> GetAuthenticatedWordPressClient(AuthMethod method = AuthMethod.JWT)
         {
-            var client = new WordPressClient(ApiCredentials.WordPressUri);
-            /*client.Username = ApiCredentials.Username;
-            client.Password = ApiCredentials.Password;*/
-            client.AuthMethod = AuthMethod.JWT;
+            var client = new WordPressClient(ApiCredentials.WordPressUri)
+            {
+                /*client.Username = ApiCredentials.Username;
+                client.Password = ApiCredentials.Password;*/
+                AuthMethod = AuthMethod.JWT
+            };
             await client.RequestJWToken(ApiCredentials.Username,ApiCredentials.Password);
 
             return client;


### PR DESCRIPTION
- remove unused HttpClient in IsValidJWToken()
- Pass JsonSerializationSettings into JsonDeserialize in HttpHelper and JsonSerialize in client classes #72 
- Add ToThreaded comments extension method #62
- reorganize ToThreaded comments tests
- code cleanup
- add "wp-json/" at the end of uri

Note: I cannot reproduce #71 situation with strange datetime format. I try to change datetime format in my WP site, but it returns correct JSON date every time. I think, that problem is on server side.