### PR TITLE
Comment.Statuses hotfix

### DIFF
--- a/WordPressPCL/Client/PostStatuses.cs
+++ b/WordPressPCL/Client/PostStatuses.cs
@@ -27,7 +27,7 @@ namespace WordPressPCL.Client
         }
 
         /// <summary>
-        /// Get latest
+        /// Get latest Post Statuses
         /// </summary>
         /// <param name="embed">include embed info</param>
         /// <param name="useAuth">Send request with authenication header</param>

--- a/WordPressPCL/Models/Enums.cs
+++ b/WordPressPCL/Models/Enums.cs
@@ -75,7 +75,7 @@ namespace WordPressPCL.Models
         /// <summary>
         /// Comment is pending to approve
         /// </summary>
-        [EnumMember(Value = "pending")]
+        [EnumMember(Value = "hold")]
         Pending,
 
         /// <summary>
@@ -83,6 +83,12 @@ namespace WordPressPCL.Models
         /// </summary>
         [EnumMember(Value = "spam")]
         Spam,
+
+        /// <summary>
+        /// Comment is is trash
+        /// </summary>
+        [EnumMember(Value = "trash")]
+        Trash,
     }
 
     /// <summary>

--- a/WordPressPCL/Models/Enums.cs
+++ b/WordPressPCL/Models/Enums.cs
@@ -85,7 +85,7 @@ namespace WordPressPCL.Models
         Spam,
 
         /// <summary>
-        /// Comment is is trash
+        /// Comment is in trash
         /// </summary>
         [EnumMember(Value = "trash")]
         Trash,

--- a/WordPressPCL/Utility/QueryBuilder.cs
+++ b/WordPressPCL/Utility/QueryBuilder.cs
@@ -45,8 +45,8 @@ namespace WordPressPCL.Utility
                 if (attribute != null)
                 {
                     var value = GetPropertyValue(property);
-                    var ttt = property.PropertyType.GetTypeInfo().IsEnum;
-                    var ppp = property.GetValue(this);
+                    //var ttt = property.PropertyType.GetTypeInfo().IsEnum;
+                    //var ppp = property.GetValue(this);
                     //pass default values
                     if (value is int && (int)value == default(int)) continue;
                     if (value is string && ((string)value == string.Empty || (string)value == DateTime.MinValue.ToString("yyyy-MM-ddTHH:mm:ss"))) continue;

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -212,14 +212,6 @@
             <param name="filename">Name of file in WP Media Library</param>
             <returns>Created media object</returns>
         </member>
-        <member name="M:WordPressPCL.Client.Media.Create(System.String,System.String)">
-            <summary>
-            Create Media entity with attachment
-            </summary>
-            <param name="filePath">Local Path to file</param>
-            <param name="filename">Name of file in WP Media Library</param>
-            <returns>Created media object</returns>
-        </member>
         <member name="M:WordPressPCL.Client.Media.Delete(System.Int32)">
             <summary>
             Delete Entity
@@ -431,6 +423,13 @@
             Constructor
             </summary>
             <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
+            <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
+        </member>
+        <member name="M:WordPressPCL.Client.PostStatuses.Get(System.Boolean,System.Boolean)">
+            <summary>
+            Get latest
+            </summary>
+            <param name="emb   <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
         <member name="M:WordPressPCL.Client.PostStatuses.Get(System.Boolean,System.Boolean)">
@@ -1042,6 +1041,11 @@
         <member name="F:WordPressPCL.Models.CommentStatus.Spam">
             <summary>
             Comment is spam
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.CommentStatus.Trash">
+            <summary>
+            Comment is is trash
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.MediaQueryStatus">

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -427,14 +427,7 @@
         </member>
         <member name="M:WordPressPCL.Client.PostStatuses.Get(System.Boolean,System.Boolean)">
             <summary>
-            Get latest
-            </summary>
-            <param name="emb   <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
-            <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
-        </member>
-        <member name="M:WordPressPCL.Client.PostStatuses.Get(System.Boolean,System.Boolean)">
-            <summary>
-            Get latest
+            Get latest Post Statuses
             </summary>
             <param name="embed">include embed info</param>
             <param name="useAuth">Send request with authenication header</param>
@@ -1045,7 +1038,7 @@
         </member>
         <member name="F:WordPressPCL.Models.CommentStatus.Trash">
             <summary>
-            Comment is is trash
+            Comment is in trash
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.MediaQueryStatus">
@@ -1874,6 +1867,16 @@
         </member>
         <member name="P:WordPressPCL.Models.Page.Author">
             <summary>
+            The id for the a  <remarks>Context: view, edit</remarks>
+        </member>
+        <member name="P:WordPressPCL.Models.Page.Excerpt">
+            <summary>
+            The excerpt for the object.
+            </summary>
+            <remarks>Context: view, edit, embed</remarks>
+        </member>
+        <member name="P:WordPressPCL.Models.Page.Author">
+            <summary>
             The id for the author of the object.
             </summary>
             <remarks>Context: view, edit, embed</remarks>
@@ -2417,19 +2420,7 @@
             Convert emoticons like :-) and :-P to graphics on display.
             </summary>
         </member>
-        <member name="P:WordPressPCL.Models.Settings.DefaultCategory">
-            <summary>
-            Default category.
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Models.Settings.DefaultPostFormat">
-            <summary>
-            Default post format.
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Models.Settings.PostsPerPage">
-            <summary>
-            Blog pages show at most.
+        <member name="P:WordPressPCL.Models.Settings.Defages show at most.
             </summary>
         </member>
         <member name="P:WordPressPCL.Models.Settings.DefaultPingStatus">
@@ -3661,6 +3652,17 @@
             Maximum number of items to be returned in result set.
             </summary>
             <remarks>Default: 10</remarks>
+        </member>
+        <member name="P:WordPressPCL.Utility.UsersQueryBuilder.Search">
+            <summary>
+            Limit results to those matching a string.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.UsersQueryBuilder.Exclude">
+            <summary>
+            Ensure result set excludes specific IDs.
+            </summary>
+       
         </member>
         <member name="P:WordPressPCL.Utility.UsersQueryBuilder.Search">
             <summary>

--- a/WordPressPCLTests/Comments_Tests.cs
+++ b/WordPressPCLTests/Comments_Tests.cs
@@ -149,6 +149,24 @@ namespace WordPressPCLTests
         }
 
         [TestMethod]
+        public async Task Comments_Query_Pending()
+        {
+            var client = await ClientHelper.GetAuthenticatedWordPressClient();
+            var queryBuilder = new CommentsQueryBuilder()
+            {
+                Page = 1,
+                PerPage = 15,
+                OrderBy = CommentsOrderBy.Id,
+                Order = Order.DESC,
+                Statuses=new CommentStatus[] {CommentStatus.Pending}
+            };
+            var queryresult = await client.Comments.Query(queryBuilder);
+            Assert.AreEqual(queryBuilder.BuildQueryURL(), "?page=1&per_page=15&orderby=id&order=desc&status=hold");
+            Assert.IsNotNull(queryresult);
+            Assert.AreNotSame(queryresult.Count(), 0);
+        }
+
+        [TestMethod]
         public async Task Comments_GetAllForPost()
         {
             var client = await ClientHelper.GetAuthenticatedWordPressClient();


### PR DESCRIPTION
This PR fix #86 issue
In WP REST API pending comments names 'hold'
+Add trash comment status