### PR TITLE
HTTPClient Header Update, Media mimetype override

### DIFF
--- a/WordPressPCL/Client/CRUDOperation.cs
+++ b/WordPressPCL/Client/CRUDOperation.cs
@@ -94,7 +94,7 @@ namespace WordPressPCL.Client
         public async Task<IEnumerable<TClass>> GetAll(bool embed = false, bool useAuth = false)
         {
             //100 - Max posts per page in WordPress REST API, so this is hack with multiple requests
-            List<TClass> entities = new List<TClass>();
+            List<TClass> entities;
             entities = (await _httpHelper.GetRequest<IEnumerable<TClass>>($"{_defaultPath}{_methodPath}?per_page=100&page=1", embed, useAuth).ConfigureAwait(false))?.ToList<TClass>();
             if (_httpHelper.LastResponseHeaders.Contains("X-WP-TotalPages") && System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-TotalPages").FirstOrDefault()) > 1)
             {

--- a/WordPressPCL/Client/Comments.cs
+++ b/WordPressPCL/Client/Comments.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -15,7 +15,6 @@ namespace WordPressPCL
     /// </summary>
     public class WordPressClient
     {
-        private readonly string _wordPressUri;
         private readonly HttpHelper _httpHelper;
         private readonly string _defaultPath;
         private const string _jwtPath = "jwt-auth/v1/";
@@ -23,10 +22,7 @@ namespace WordPressPCL
         /// <summary>
         /// WordPressUri holds the WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/wp/v2/"
         /// </summary>
-		public string WordPressUri
-        {
-            get { return _wordPressUri; }
-        }
+		public string WordPressUri { get; private set; }
 
         /// <summary>
         /// Function called when a HttpRequest response to WordPress APIs are read
@@ -65,12 +61,12 @@ namespace WordPressPCL
         /// <summary>
         /// Posts client interaction object
         /// </summary>
-        public Posts Posts;
+        public Posts Posts { get; }
 
         /// <summary>
         /// Comments client interaction object
         /// </summary>
-        public Comments Comments;
+        public Comments Comments { get; }
 
         /// <summary>
         /// Tags client interaction object
@@ -132,7 +128,7 @@ namespace WordPressPCL
             {
                 uri += "/";
             }
-            _wordPressUri = uri;
+            WordPressUri = uri;
             _defaultPath = defaultPath;
 
             _httpHelper = new HttpHelper(WordPressUri);
@@ -210,15 +206,8 @@ namespace WordPressPCL
         public async Task<bool> IsValidJWToken()
         {
             var route = $"{_jwtPath}token/validate";
-            try
-            {
-                (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true).ConfigureAwait(false);
-                return repsonse.IsSuccessStatusCode;
-            }
-            catch
-            {
-                return false;
-            }
+            (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true).ConfigureAwait(false);
+            return repsonse.IsSuccessStatusCode;
         }
 
         /// <summary>

--- a/WordPressPCL/WordPressPCL.csproj
+++ b/WordPressPCL/WordPressPCL.csproj
@@ -74,7 +74,7 @@ V1.2
 - added method to get all comments for a post id
 - fixed some async issues for better performance
 - added logout method</PackageReleaseNotes>
-    <Copyright>© Thomas Pentenrieder | 2019</Copyright>
+    <Copyright>© Thomas Pentenrieder | 2020</Copyright>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/WordPressPCL/WordPressPCL.csproj
+++ b/WordPressPCL/WordPressPCL.csproj
@@ -81,6 +81,10 @@ V1.2
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -204,11 +204,20 @@
             <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
             <param name="defaultPath">path to site, EX. http://demo.com/wp-json/ </param>
         </member>
-        <member name="M:WordPressPCL.Client.Media.Create(System.IO.Stream,System.String)">
+        <member name="M:WordPressPCL.Client.Media.Create(System.IO.Stream,System.String,System.String)">
             <summary>
             Create Media entity with attachment
             </summary>
             <param name="fileStream">stream with file content</param>
+            <param name="filename">Name of file in WP Media Library</param>
+            <param name="mimeType">Override for automatic mime type detection</param>
+            <returns>Created media object</returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Media.Create(System.String,System.String,System.String)">
+            <summary>
+            Create Media entity with attachment
+            </summary>
+            <param name="filePath">Local Path to file</param>
             <param name="filename">Name of file in WP Media Library</param>
             <returns>Created media object</returns>
         </member>
@@ -688,15 +697,6 @@
             <param name="useAuth">Is use auth header</param>
             <returns>requested object</returns>
         </member>
-        <member name="M:WordPressPCL.Interfaces.IReatem.Boolean,System.Boolean)">
-            <summary>
-            Get object by Id
-            </summary>
-            <param name="ID">Object Id</param>
-            <param name="embed">Is use embed info</param>
-            <param name="useAuth">Is use auth header</param>
-            <returns>requested object</returns>
-        </member>
         <member name="M:WordPressPCL.Interfaces.IReadOperation`1.GetAll(System.Boolean,System.Boolean)">
             <summary>
             Get all objects
@@ -799,7 +799,18 @@
             Number of published posts for the term.
             </summary>
             <remarks>
-            Read
+            Read only
+            Context: view, edit
+            </remarks>
+        </member>
+        <member name="P:WordPressPCL.Models.Category.Description">
+            <summary>
+            HTML description of the term.
+            </summary>
+            <remarks>Context: view, edit</remarks>
+        </member>
+        <member name="P:WordPressPCL.Models.Category.Parent">
+            <summary>
             The parent term ID.
             </summary>
             <remarks>Context: view, edit</remarks>
@@ -3785,12 +3796,12 @@
             Authentication method
             </summary>
         </member>
-        <member name="F:WordPressPCL.WordPressClient.Posts">
+        <member name="P:WordPressPCL.WordPressClient.Posts">
             <summary>
             Posts client interaction object
             </summary>
         </member>
-        <member name="F:WordPressPCL.WordPressClient.Comments">
+        <member name="P:WordPressPCL.WordPressClient.Comments">
             <summary>
             Comments client interaction object
             </summary>
@@ -3879,20 +3890,6 @@
             <returns>Result of checking</returns>
         </member>
         <member name="M:WordPressPCL.WordPressClient.SetJWToken(System.String)">
-            <summary>
-            Sets an existing JWToken
-            </summary>
-            <param name="token"></param>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.GetToken">
-            <summary>
-            Gets the JWToken from the client
-            </summary>
-            <returns></returns>
-        </member>
-    </members>
-</doc>
-ystem.String)">
             <summary>
             Sets an existing JWToken
             </summary>


### PR DESCRIPTION
- Changed HttpClient to pass auth headers directly in the request, not modifying the actual client
- Added mimetype override for Media Create methods
- Some code cleanup