### PR TITLE
Jwt auth support

### DIFF
--- a/WordPressPCL/Models/AuthMethod.cs
+++ b/WordPressPCL/Models/AuthMethod.cs
@@ -9,8 +9,12 @@ namespace WordPressPCL.Models
     public enum AuthMethod
     {
         /// <summary>
-        /// JSON Web Token Authentication method. Need configure your site with this plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
+        /// JSON Web Token Authentication method by Enrique Chavez. Need configure your site with this plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
         /// </summary>
-        JWT
+        JWT,
+        /// <summary>
+        /// JSON Web Token Authentication method by Useful Team. Need configure your site with this plugin https://wordpress.org/plugins/jwt-auth/
+        /// </summary>
+        JWTAuth
     }
 }

--- a/WordPressPCL/Models/JWTData.cs
+++ b/WordPressPCL/Models/JWTData.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace WordPressPCL.Models
+{
+    class JWTData
+    {
+        [JsonProperty("token")]
+        public String Token { get; set; }
+
+        [JsonProperty("displayName")]
+        public String DisplayName{ get; set; }
+
+        [JsonProperty("email")]
+        public String Email { get; set; }
+
+        [JsonProperty("nicename")]
+        public String NiceName { get; set; }
+    }
+}

--- a/WordPressPCL/Models/JWTResponse.cs
+++ b/WordPressPCL/Models/JWTResponse.cs
@@ -1,0 +1,18 @@
+﻿using Newtonsoft.Json;
+using System.ComponentModel;
+
+namespace WordPressPCL.Models
+{
+    class JWTResponse
+    {
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
+        [JsonProperty("data")]
+        [DefaultValue(null)]
+        public JWTData Data { get; set; }
+    }
+}

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -186,8 +187,16 @@ namespace WordPressPCL
                     new KeyValuePair<string, string>("username", Username),
                     new KeyValuePair<string, string>("password", Password)
                 });
-            (JWTUser jwtUser, _) = await _httpHelper.PostRequest<JWTUser>(route, formContent, false).ConfigureAwait(false);
-            _httpHelper.JWToken = jwtUser?.Token;
+            if (AuthMethod == AuthMethod.JWT)
+            {
+                (JWTUser jwtUser, _) = await _httpHelper.PostRequest<JWTUser>(route, formContent, false).ConfigureAwait(false);
+                _httpHelper.JWToken = jwtUser?.Token;
+            }
+            else
+            {
+                (JWTResponse jwtResponse, _) = await _httpHelper.PostRequest<JWTResponse>(route, formContent, false).ConfigureAwait(false);
+                _httpHelper.JWToken = jwtResponse?.Data?.Token;
+            }
         }
 
         /// <summary>
@@ -207,13 +216,38 @@ namespace WordPressPCL
             var route = $"{_jwtPath}token/validate";
             try
             {
-                (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true).ConfigureAwait(false);
-                return repsonse.IsSuccessStatusCode;
+                if (AuthMethod == AuthMethod.JWT)
+                {
+                    (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true).ConfigureAwait(false);
+                    return repsonse.IsSuccessStatusCode;
+                }
+                else
+                {
+                    HttpResponsePreProcessing = RemoveEmptyData;
+                    (JWTResponse jwtResponse, _) = await _httpHelper.PostRequest<JWTResponse>(route, null, true).ConfigureAwait(false);
+                    HttpResponsePreProcessing = null;
+                    return jwtResponse.Success;
+                }
             }
             catch (WPException)
             {
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Removes an empty data field in a Json string, e.g. when checking validity of token
+        /// </summary>
+        /// <param name="response">Json response input string</param>
+        /// <returns>Json response output string</returns>
+        private string RemoveEmptyData(string response)
+        {
+            JObject jo = JObject.Parse(response);
+            if (!jo.SelectToken("data").HasValues)
+            {
+                jo.Remove("data");
+            }
+            return jo.ToString();
         }
 
         /// <summary>

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -192,12 +192,16 @@ namespace WordPressPCL
                 (JWTUser jwtUser, _) = await _httpHelper.PostRequest<JWTUser>(route, formContent, false).ConfigureAwait(false);
                 _httpHelper.JWToken = jwtUser?.Token;
             }
-            else
+            else if (AuthMethod == AuthMethod.JWTAuth)
             {
                 HttpResponsePreProcessing = RemoveEmptyData;
                 (JWTResponse jwtResponse, _) = await _httpHelper.PostRequest<JWTResponse>(route, formContent, false).ConfigureAwait(false);
                 HttpResponsePreProcessing = null;
                 _httpHelper.JWToken = jwtResponse?.Data?.Token;
+            }
+            else
+            {
+                throw new ArgumentException($"Authentication methode {AuthMethod} is not supported");
             }
         }
 
@@ -223,12 +227,16 @@ namespace WordPressPCL
                     (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequest<JWTUser>(route, null, true).ConfigureAwait(false);
                     return repsonse.IsSuccessStatusCode;
                 }
-                else
+                else if (AuthMethod == AuthMethod.JWTAuth)
                 {
                     HttpResponsePreProcessing = RemoveEmptyData;
                     (JWTResponse jwtResponse, _) = await _httpHelper.PostRequest<JWTResponse>(route, null, true).ConfigureAwait(false);
                     HttpResponsePreProcessing = null;
                     return jwtResponse.Success;
+                }
+                else
+                {
+                    throw new ArgumentException($"Authentication methode {AuthMethod} is not supported");
                 }
             }
             catch (WPException)

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -194,7 +194,9 @@ namespace WordPressPCL
             }
             else
             {
+                HttpResponsePreProcessing = RemoveEmptyData;
                 (JWTResponse jwtResponse, _) = await _httpHelper.PostRequest<JWTResponse>(route, formContent, false).ConfigureAwait(false);
+                HttpResponsePreProcessing = null;
                 _httpHelper.JWToken = jwtResponse?.Data?.Token;
             }
         }

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -727,7 +727,12 @@
         </member>
         <member name="F:WordPressPCL.Models.AuthMethod.JWT">
             <summary>
-            JSON Web Token Authentication method. Need configure your site with this plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
+            JSON Web Token Authentication method by Enrique Chavez. Need configure your site with this plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.AuthMethod.JWTAuth">
+            <summary>
+            JSON Web Token Authentication method by Useful Team. Need configure your site with this plugin https://wordpress.org/plugins/jwt-auth/
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.AvatarURL">
@@ -3920,6 +3925,13 @@
             Check if token is valid
             </summary>
             <returns>Result of checking</returns>
+        </member>
+        <member name="M:WordPressPCL.WordPressClient.RemoveEmptyData(System.String)">
+            <summary>
+            Removes an empty data field in a Json string, e.g. when checking validity of token
+            </summary>
+            <param name="response">Json response input string</param>
+            <returns>Json response output string</returns>
         </member>
         <member name="M:WordPressPCL.WordPressClient.SetJWToken(System.String)">
             <summary>


### PR DESCRIPTION
Added JWTAuth authentication method which supports the "JWT Auth" plugin of "Useful Team"

Tests are not updated yet. Should we create an additional class like `ApiCredentials` which points to another Wordpress instance running the `JWT Auth` plugin or should we just add another Uri like `ApiCredentials.WordPressUriJwtAuth`?

After this decision, I will extend `JWTAuthTest()` resp. add a similar test.