### PR TITLE
Enable pagination result with QueryResult<T>

### DIFF
--- a/Test/Program.cs
+++ b/Test/Program.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text.Json;
+using WordPressPCL;
+using WordPressPCL.Client;
+using WordPressPCL.Models;
+using WordPressPCL.Utility;
+
+namespace Test
+{
+    class Program
+    {
+        public static string SiteUri = "mysite.wordpress.com";
+        public static string WordPressUri = $"https://public-api.wordpress.com/wp/v2/sites/{SiteUri}/";
+
+        static async Task Main(string[] args)
+        {
+            var client = new WordPressClient(WordPressUri, "");
+
+             var queryBuilder = new PostsQueryBuilder()
+            {
+                Page = 1,
+                PerPage = 15,
+                OrderBy = PostsOrderBy.Title,
+                Order = Order.ASC,
+                Statuses = new Status[] { Status.Publish },
+                Embed = true
+            };
+            var queryresult = await client.Posts.Query(queryBuilder);
+
+            Console.WriteLine(queryresult.Total);
+            Console.WriteLine(queryresult.TotalPages);
+            Console.WriteLine(JsonSerializer.Serialize(queryresult.Count()));
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\WordPressPCL\WordPressPCL.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/WordPressPCL/Client/CRUDOperation.cs
+++ b/WordPressPCL/Client/CRUDOperation.cs
@@ -131,9 +131,12 @@ namespace WordPressPCL.Client
         /// <param name="queryBuilder">Query builder with specific parameters</param>
         /// <param name="useAuth">Send request with authentication header</param>
         /// <returns>List of filtered result</returns>
-        public Task<IEnumerable<TClass>> Query(QClass queryBuilder, bool useAuth = false)
+        public async Task<QueryResult<TClass>> Query(QClass queryBuilder, bool useAuth = false)
         {
-            return HttpHelper.GetRequest<IEnumerable<TClass>>($"{DefaultPath}{MethodPath}{queryBuilder.BuildQueryURL()}", false, useAuth);
+            var result = await HttpHelper.GetRequest<IEnumerable<TClass>>($"{DefaultPath}{MethodPath}{queryBuilder.BuildQueryURL()}", false, useAuth);
+            int total = System.Convert.ToInt32(HttpHelper.LastResponseHeaders.GetValues("X-WP-Total").FirstOrDefault());
+            int totalpages = System.Convert.ToInt32(HttpHelper.LastResponseHeaders.GetValues("X-WP-TotalPages").FirstOrDefault());
+            return new QueryResult<TClass>(result, total, totalpages);
         }
 
         /// <summary>

--- a/WordPressPCL/Client/Media.cs
+++ b/WordPressPCL/Client/Media.cs
@@ -159,9 +159,12 @@ namespace WordPressPCL.Client
         /// <param name="queryBuilder">Query builder with specific parameters</param>
         /// <param name="useAuth">Send request with authentication header</param>
         /// <returns>List of filtered result</returns>
-        public Task<IEnumerable<MediaItem>> Query(MediaQueryBuilder queryBuilder, bool useAuth = false)
+        public async Task<QueryResult<MediaItem>> Query(MediaQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return _httpHelper.GetRequest<IEnumerable<MediaItem>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false, useAuth);
+            var results = await _httpHelper.GetRequest<IEnumerable<MediaItem>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false, useAuth);
+            int total = System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-Total").FirstOrDefault());
+            int totalpages = System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-TotalPages").FirstOrDefault());
+            return new QueryResult<MediaItem>(results, total, totalpages);
         }
 
         /// <summary>

--- a/WordPressPCL/Client/Taxonomies.cs
+++ b/WordPressPCL/Client/Taxonomies.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using WordPressPCL.Interfaces;
 using WordPressPCL.Models;
@@ -78,7 +79,7 @@ namespace WordPressPCL.Client
         /// <param name="queryBuilder">Query builder with specific parameters</param>
         /// <param name="useAuth">Send request with authentication header</param>
         /// <returns>List of filtered result</returns>
-        public async Task<IEnumerable<Taxonomy>> Query(TaxonomiesQueryBuilder queryBuilder, bool useAuth = false)
+        public async Task<QueryResult<Taxonomy>> Query(TaxonomiesQueryBuilder queryBuilder, bool useAuth = false)
         {
             List<Taxonomy> entities = new List<Taxonomy>();
             var entities_dict = await _httpHelper.GetRequest<Dictionary<string, Taxonomy>>($"{_defaultPath}{_methodPath}{queryBuilder.BuildQueryURL()}", false, useAuth).ConfigureAwait(false);
@@ -86,7 +87,9 @@ namespace WordPressPCL.Client
             {
                 entities.Add(ent.Value);
             }
-            return entities;
+            int total = System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-Total").FirstOrDefault());
+            int totalpages = System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-TotalPages").FirstOrDefault());
+            return new QueryResult<Taxonomy>(entities, total, totalpages);
         }
     }
 }

--- a/WordPressPCL/Client/Users.cs
+++ b/WordPressPCL/Client/Users.cs
@@ -98,9 +98,12 @@ namespace WordPressPCL.Client
         /// <param name="queryBuilder">Query builder with specific parameters</param>
         /// <param name="useAuth">Send request with authentication header</param>
         /// <returns>List of filtered result</returns>
-        public Task<IEnumerable<User>> Query(UsersQueryBuilder queryBuilder, bool useAuth = false)
+        public async Task<QueryResult<User>> Query(UsersQueryBuilder queryBuilder, bool useAuth = false)
         {
-            return _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{METHOD_PATH}{queryBuilder.BuildQueryURL()}", false, useAuth);
+            var results = await _httpHelper.GetRequest<IEnumerable<User>>($"{_defaultPath}{METHOD_PATH}{queryBuilder.BuildQueryURL()}", false, useAuth);
+            int total = System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-Total").FirstOrDefault());
+            int totalpages = System.Convert.ToInt32(_httpHelper.LastResponseHeaders.GetValues("X-WP-TotalPages").FirstOrDefault());
+            return new QueryResult<User>(results, total, totalpages);
         }
 
         /// <summary>

--- a/WordPressPCL/Interfaces/IQueryOperation.cs
+++ b/WordPressPCL/Interfaces/IQueryOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using WordPressPCL.Models;
 using WordPressPCL.Utility;
 
 namespace WordPressPCL.Interfaces
@@ -17,6 +18,6 @@ namespace WordPressPCL.Interfaces
         /// <param name="queryBuilder">query builder with parameters for query</param>
         /// <param name="useAuth">Is use auth header</param>
         /// <returns>list of filtered objects</returns>
-        Task<IEnumerable<TClass>> Query(QClass queryBuilder, bool useAuth = false);
+        Task<QueryResult<TClass>> Query(QClass queryBuilder, bool useAuth = false);
     }
 }

--- a/WordPressPCL/Models/QueryResult.cs
+++ b/WordPressPCL/Models/QueryResult.cs
@@ -1,0 +1,34 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace WordPressPCL.Models
+{
+    /// <summary>
+    /// Base class for query results
+    /// </summary>
+    public class QueryResult<T> : IEnumerable<T>
+    {
+        private readonly IEnumerable<T> items;
+
+        public QueryResult(IEnumerable<T> items, int total, int totalPages) 
+        {
+            this.items = items;
+            Total = total;
+            TotalPages = totalPages;
+        }
+
+        public int Total { get; }
+
+         public int TotalPages { get; }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -610,6 +610,19 @@
             </summary>
             <returns>Current User</returns>
         </member>
+        <member name="M:WordPressPCL.rdPressPCL.Client.Users.Update(WordPressPCL.Models.User)">
+            <summary>
+            Update Entity
+            </summary>
+            <param name="Entity">Entity object</param>
+            <returns>Updated object</returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Users.GetCurrentUser">
+            <summary>
+            Get current User
+            </summary>
+            <returns>Current User</returns>
+        </member>
         <member name="M:WordPressPCL.Client.Users.Delete(System.Int32,System.Int32)">
             <summary>
             Delete user with reassign articles
@@ -690,17 +703,7 @@
         <member name="M:WordPressPCL.Interfaces.IReadOperation`1.Get(System.Boolean,System.Boolean)">
             <summary>
             Get latest
-            </summary>
-            <param name="embed">Is use embed info</param>
-            <param name="useAuth">Is use auth header</param>
-            <returns>requested object</returns>
-        </member>
-        <member name="M:WordPressPCL.Interfaces.IReadOperation`1.GetByID(System.Object,System.Boolean,System.Boolean)">
-            <summary>
-            Get object by Id
-            </summary>
-            <param name="ID">Object Id</param>
-            <param name="embed">Is use embed info</param>
+            aram>
             <param name="useAuth">Is use auth header</param>
             <returns>requested object</returns>
         </member>
@@ -795,6 +798,22 @@
         <member name="P:WordPressPCL.Models.Base.Id">
             <summary>
             Unique identifier for the object.
+            </summary>
+            <remarks>
+            Read only
+            Context: view, edit, embed
+            </remarks>
+        </member>
+        <member name="T:WordPressPCL.Models.Category">
+            <summary>
+            Terms of the type category
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Category.Count">
+            <summary>
+            Number of published posts for the term.
+            </summary>
+ dentifier for the object.
             </summary>
             <remarks>
             Read only
@@ -908,20 +927,7 @@
             <summary>
             The date the object was published.
             </summary>
-            <remarks>Context: view, edit, embed</remarks>
-        </member>
-        <member name="P:WordPressPCL.Models.Comment.DateGmt">
-            <summary>
-            The date the object was published as GMT.
-            </summary>
-            <remarks>Context: view, edit</remarks>
-        </member>
-        <member name="P:WordPressPCL.Models.Comment.Content">
-            <summary>
-            The content for the object.
-            <see cref="T:WordPressPCL.Models.Content"/>
-            </summary>
-            <remarks>Context: view, edit, embed</remarks>
+            <remarks>Context: view, edit,Context: view, edit, embed</remarks>
         </member>
         <member name="P:WordPressPCL.Models.Comment.Link">
             <summary>
@@ -2455,12 +2461,31 @@
         </member>
         <member name="P:WordPressPCL.Models.PostType.Links">
             <summary>
+         dels.PostType.Taxonomies">
+            <summary>
+            List of taxonomies
+            </summary>
+            <remarks>Context: edit</remarks>
+        </member>
+        <member name="P:WordPressPCL.Models.PostType.RestBase">
+            <summary>
+            REST base route for the taxonomy.
+            </summary>
+            <remarks>Context: view, edit, embed</remarks>
+        </member>
+        <member name="P:WordPressPCL.Models.PostType.Links">
+            <summary>
             Links to related resources
             </summary>
         </member>
         <member name="M:WordPressPCL.Models.PostType.#ctor">
             <summary>
             Default constructor
+            </summary>
+        </member>
+        <member name="T:WordPressPCL.Models.QueryResult`1">
+            <summary>
+            Base class for query results
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.Settings">
@@ -3990,20 +4015,6 @@
             <param name="token"></param>
         </member>
         <member name="M:WordPressPCL.WordPressClient.GetToken">
-            <summary>
-            Gets the JWToken from the client
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.SetApplicationPassword(System.String)">
-            <summary>
-            Store Application Password in the Client
-            </summary>
-            <param name="applictionPassword"></param>
-        </member>
-    </members>
-</doc>
-   <member name="M:WordPressPCL.WordPressClient.GetToken">
             <summary>
             Gets the JWToken from the client
             </summary>


### PR DESCRIPTION
This adds the ability to get the current Total and TotalPage in the result of a query, by adding the ```QueryResult<T>``` class.

I chose to go the easy way, similar to other places in the code, parse the headers of the last request, and put them and the resulting items into ```QueryResult<T>```. 

The QueryResult<T> is a custom collection class that substitutes the use of ```IEnumerable<T>``` as return type for IQueryOperation<TClass, QClass>.Query(...). It implements ```IEnumerable<T>``` so enumeration will still be possible.

XML documentation TBA

I will remove the Test project