### PR TITLE
Default Mime Type change

### DIFF
--- a/WordPressPCL.Tests.Selfhosted/MimeTypeHelper_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/MimeTypeHelper_Tests.cs
@@ -1,0 +1,21 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WordPressPCL.Utility;
+
+namespace WordPressPCL.Tests.Selfhosted {
+    
+    [TestClass]
+    public class MimeTypeHelper_Tests {
+
+        [TestMethod]
+        public void MimeType_Defaults_To_Application_Octet_Stream_For_Unknown_Extension() {
+            const string unknownExtension = "unknown";
+            const string expectedMimeType = "application/octet-stream";
+
+            var resultMimeType = MimeTypeHelper.GetMIMETypeFromExtension(unknownExtension);
+
+            Assert.AreEqual(expectedMimeType, resultMimeType);
+        }
+
+    }
+    
+}

--- a/WordPressPCL/Utility/MimeTypeHelper.cs
+++ b/WordPressPCL/Utility/MimeTypeHelper.cs
@@ -15,7 +15,7 @@ namespace WordPressPCL.Utility
         public static string GetMIMETypeFromExtension(string extension)
         {
             //List from https://codex.wordpress.org/Function_Reference/get_allowed_mime_types
-            return (extension?.ToLower(CultureInfo.InvariantCulture)) switch
+            return extension?.ToLower(CultureInfo.InvariantCulture) switch
             {
                 // Image formats
                 "jpg" or "jpeg" or "jpe" => "image/jpeg",
@@ -119,7 +119,7 @@ namespace WordPressPCL.Utility
 
                 //Misc Application/octet-stream formats
                 "kmz" or "kml" => "application/octet-stream",
-                _ => "text/plain",
+                _ => "application/octet-stream"
             };
         }
     }


### PR DESCRIPTION
The default mime type of unknown extensions is changed from text/plain to application/octet-stream. This is in accordance with: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types