### PR TITLE
Auth sub client refactoring

### DIFF
--- a/WordPressPCL.Tests.Hosted/Utility/HttpHelper_Tests.cs
+++ b/WordPressPCL.Tests.Hosted/Utility/HttpHelper_Tests.cs
@@ -23,7 +23,7 @@ namespace WordPressPCL.Tests.Hosted.Utility
             {
                 AuthMethod = AuthMethod.JWT
             };
-            await client.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
+            await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 
             // Create a random tag , must works:
             var random = new Random();
@@ -62,7 +62,7 @@ namespace WordPressPCL.Tests.Hosted.Utility
             {
                 AuthMethod = AuthMethod.JWT
             };
-            await client.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
+            await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 
             // Create a random tag
             var random = new Random();

--- a/WordPressPCL.Tests.Selfhosted/ApplicationPasswords_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/ApplicationPasswords_Tests.cs
@@ -58,7 +58,7 @@ namespace WordPressPCL.Tests.Selfhosted
                 AuthMethod = AuthMethod.ApplicationPassword,
                 UserName = ApiCredentials.Username
             };
-            appPasswordClient.SetApplicationPassword(appPassword.Password);
+            appPasswordClient.Auth.SetApplicationPassword(appPassword.Password);
 
             var post = new Post()
             {

--- a/WordPressPCL.Tests.Selfhosted/Basic_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Basic_Tests.cs
@@ -127,7 +127,7 @@ namespace WordPressPCL.Tests.Selfhosted
                 Assert.Inconclusive();
                 return;
             }
-            var validToken = await _clientAuth.IsValidJWTokenAsync();
+            var validToken = await _clientAuth.Auth.IsValidJWTokenAsync();
             Assert.IsTrue(validToken);
         }
     }

--- a/WordPressPCL.Tests.Selfhosted/CommentsThreaded_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/CommentsThreaded_Tests.cs
@@ -24,7 +24,7 @@ namespace WordPressPCL.Tests.Selfhosted
         public static async Task CommentsThreaded_SetupAsync(TestContext testContext)
         {
             _clientAuth = await ClientHelper.GetAuthenticatedWordPressClient(testContext);
-            var IsValidToken = await _clientAuth.IsValidJWTokenAsync();
+            var IsValidToken = await _clientAuth.Auth.IsValidJWTokenAsync();
             Assert.IsTrue(IsValidToken);
 
             var post = await _clientAuth.Posts.CreateAsync(new Post()

--- a/WordPressPCL.Tests.Selfhosted/HttpClient_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/HttpClient_Tests.cs
@@ -29,8 +29,8 @@ namespace WordPressPCL.Tests.Selfhosted
             Assert.IsTrue(posts.First().Id == post.Id);
             Assert.IsTrue(!string.IsNullOrEmpty(posts.First().Content.Rendered));
 
-            await client.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
-            var validToken = await client.IsValidJWTokenAsync();
+            await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
+            var validToken = await client.Auth.IsValidJWTokenAsync();
             Assert.IsTrue(validToken);
         }
     }

--- a/WordPressPCL.Tests.Selfhosted/Utility/ClientHelper.cs
+++ b/WordPressPCL.Tests.Selfhosted/Utility/ClientHelper.cs
@@ -21,7 +21,7 @@ namespace WordPressPCL.Tests.Selfhosted.Utility
             {
                 clientAuth.AuthMethod = AuthMethod.JWT;
             }
-            await clientAuth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
+            await clientAuth.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 
             return clientAuth;
         }

--- a/WordPressPCL/Client/Auth.cs
+++ b/WordPressPCL/Client/Auth.cs
@@ -1,0 +1,134 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using WordPressPCL.Models;
+using WordPressPCL.Models.Exceptions;
+using WordPressPCL.Utility;
+
+namespace WordPressPCL.Client {
+
+    /// <summary>
+    /// Client class for interaction with Auth endpoints of WP REST API
+    /// </summary>
+    public class Auth 
+    {
+
+        private const string JwtPath = "jwt-auth/v1/";
+
+        /// <summary>
+        /// Authentication Method
+        /// </summary>
+        internal AuthMethod AuthMethod { get; set; }
+
+        /// <summary>
+        /// Helper for HTTP requests
+        /// </summary>
+        private readonly HttpHelper _httpHelper;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
+        public Auth(ref HttpHelper httpHelper) 
+        {
+            _httpHelper = httpHelper;
+        }
+
+        /// <summary>
+        /// Perform authentication by JWToken
+        /// </summary>
+        /// <param name="username">username</param>
+        /// <param name="Password">password</param>
+        public async Task RequestJWTokenAsync(string username, string Password) {
+            var route = $"{JwtPath}token";
+            using var formContent = new FormUrlEncodedContent(new[]
+                {
+                    new KeyValuePair<string, string>("username", username),
+                    new KeyValuePair<string, string>("password", Password)
+                });
+            if (AuthMethod == AuthMethod.JWT) {
+                (JWTUser jwtUser, _) = await _httpHelper.PostRequestAsync<JWTUser>(route, formContent, false).ConfigureAwait(false);
+                _httpHelper.JWToken = jwtUser?.Token;
+            } else if (AuthMethod == AuthMethod.JWTAuth) {
+                _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
+                (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, formContent, false).ConfigureAwait(false);
+                _httpHelper.HttpResponsePreProcessing = null;
+                _httpHelper.JWToken = jwtResponse?.Data?.Token;
+            } else {
+                throw new ArgumentException($"Authentication methode {AuthMethod} is not supported");
+            }
+        }
+
+        /// <summary>
+        /// Forget the JWT Auth Token, won't invalidate it serverside though
+        /// </summary>
+        public void Logout() {
+            _httpHelper.JWToken = default;
+            _httpHelper.ApplicationPassword = default;
+        }
+
+        /// <summary>
+        /// Check if token is valid
+        /// </summary>
+        /// <returns>Result of checking</returns>
+        public async Task<bool> IsValidJWTokenAsync() {
+            var route = $"{JwtPath}token/validate";
+            try {
+                if (AuthMethod == AuthMethod.JWT) {
+                    (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequestAsync<JWTUser>(route, null, true).ConfigureAwait(false);
+                    return repsonse.IsSuccessStatusCode;
+                } else if (AuthMethod == AuthMethod.JWTAuth) {
+                    _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
+                    (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, null, true).ConfigureAwait(false);
+                    _httpHelper.HttpResponsePreProcessing = null;
+                    return jwtResponse.Success;
+                } else {
+                    throw new ArgumentException($"Authentication method {AuthMethod} is not supported");
+                }
+            } catch (WPException) {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Removes an empty data field in a Json string, e.g. when checking validity of token
+        /// </summary>
+        /// <param name="response">Json response input string</param>
+        /// <returns>Json response output string</returns>
+        private string RemoveEmptyData(string response) {
+            JObject jo = JObject.Parse(response);
+            if (!jo.SelectToken("data").HasValues) {
+                jo.Remove("data");
+            }
+            return jo.ToString();
+        }
+
+        /// <summary>
+        /// Sets an existing JWToken
+        /// </summary>
+        /// <param name="token"></param>
+        public void SetJWToken(string token) {
+            _httpHelper.JWToken = token;
+        }
+
+        /// <summary>
+        /// Gets the JWToken from the client
+        /// </summary>
+        /// <returns></returns>
+        public string GetToken() {
+            return _httpHelper.JWToken;
+        }
+
+        /// <summary>
+        /// Store Application Password in the Client
+        /// </summary>
+        /// <param name="applicationPassword"></param>
+        public void SetApplicationPassword(string applicationPassword) {
+            _httpHelper.ApplicationPassword = applicationPassword;
+        }
+
+    }
+}

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -20,7 +20,6 @@ namespace WordPressPCL
         private readonly HttpHelper _httpHelper;
         private const string DEFAULT_PATH = "wp/v2/";
         private readonly string _defaultPath;
-        private const string _jwtPath = "jwt-auth/v1/";
 
         /// <summary>
         /// WordPressUri holds the WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/wp/v2/"
@@ -59,7 +58,11 @@ namespace WordPressPCL
         public AuthMethod AuthMethod 
         {
             get => _httpHelper.AuthMethod;
-            set => _httpHelper.AuthMethod = value;
+            set 
+            { 
+                _httpHelper.AuthMethod = value;
+                Auth.AuthMethod = value;
+            }
         }
 
         /// <summary>
@@ -69,6 +72,11 @@ namespace WordPressPCL
             get => _httpHelper.UserName;
             set => _httpHelper.UserName = value;
         }
+
+        /// <summary>
+        /// Auth client interaction object
+        /// </summary>
+        public Auth Auth { get; }
 
         //public string JWToken;
         /// <summary>
@@ -145,6 +153,7 @@ namespace WordPressPCL
             _defaultPath = defaultPath;
 
             _httpHelper = new HttpHelper(WordPressUri);
+            Auth = new Auth(ref _httpHelper);
             Posts = new Posts(ref _httpHelper, _defaultPath);
             Comments = new Comments(ref _httpHelper, _defaultPath);
             Tags = new Tags(ref _httpHelper, _defaultPath);
@@ -178,6 +187,7 @@ namespace WordPressPCL
             _defaultPath = defaultPath;
 
             _httpHelper = new HttpHelper(httpClient);
+            Auth = new Auth(ref _httpHelper);
             Posts = new Posts(ref _httpHelper, _defaultPath);
             Comments = new Comments(ref _httpHelper, _defaultPath);
             Tags = new Tags(ref _httpHelper, _defaultPath);
@@ -216,122 +226,5 @@ namespace WordPressPCL
 
         #endregion Settings methods
 
-        #region auth methods
-
-        /// <summary>
-        /// Perform authentication by JWToken
-        /// </summary>
-        /// <param name="Username">username</param>
-        /// <param name="Password">password</param>
-        public async Task RequestJWTokenAsync(string Username, string Password)
-        {
-            var route = $"{_jwtPath}token";
-            using var formContent = new FormUrlEncodedContent(new[]
-                {
-                    new KeyValuePair<string, string>("username", Username),
-                    new KeyValuePair<string, string>("password", Password)
-                });
-            if (AuthMethod == AuthMethod.JWT)
-            {
-                (JWTUser jwtUser, _) = await _httpHelper.PostRequestAsync<JWTUser>(route, formContent, false).ConfigureAwait(false);
-                _httpHelper.JWToken = jwtUser?.Token;
-            }
-            else if (AuthMethod == AuthMethod.JWTAuth)
-            {
-                HttpResponsePreProcessing = RemoveEmptyData;
-                (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, formContent, false).ConfigureAwait(false);
-                HttpResponsePreProcessing = null;
-                _httpHelper.JWToken = jwtResponse?.Data?.Token;
-            }
-            else
-            {
-                throw new ArgumentException($"Authentication methode {AuthMethod} is not supported");
-            }
-        }
-
-        /// <summary>
-        /// Forget the JWT Auth Token, won't invalidate it serverside though
-        /// </summary>
-        public void Logout()
-        {
-            _httpHelper.JWToken = default;
-            _httpHelper.ApplicationPassword = default;
-        }
-
-        /// <summary>
-        /// Check if token is valid
-        /// </summary>
-        /// <returns>Result of checking</returns>
-        public async Task<bool> IsValidJWTokenAsync()
-        {
-            var route = $"{_jwtPath}token/validate";
-            try
-            {
-                if (AuthMethod == AuthMethod.JWT)
-                {
-                    (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequestAsync<JWTUser>(route, null, true).ConfigureAwait(false);
-                    return repsonse.IsSuccessStatusCode;
-                }
-                else if (AuthMethod == AuthMethod.JWTAuth)
-                {
-                    HttpResponsePreProcessing = RemoveEmptyData;
-                    (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, null, true).ConfigureAwait(false);
-                    HttpResponsePreProcessing = null;
-                    return jwtResponse.Success;
-                }
-                else
-                {
-                    throw new ArgumentException($"Authentication methode {AuthMethod} is not supported");
-                }
-            }
-            catch (WPException)
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Removes an empty data field in a Json string, e.g. when checking validity of token
-        /// </summary>
-        /// <param name="response">Json response input string</param>
-        /// <returns>Json response output string</returns>
-        private string RemoveEmptyData(string response)
-        {
-            JObject jo = JObject.Parse(response);
-            if (!jo.SelectToken("data").HasValues)
-            {
-                jo.Remove("data");
-            }
-            return jo.ToString();
-        }
-
-        /// <summary>
-        /// Sets an existing JWToken
-        /// </summary>
-        /// <param name="token"></param>
-        public void SetJWToken(string token)
-        {
-            _httpHelper.JWToken = token;
-        }
-
-        /// <summary>
-        /// Gets the JWToken from the client
-        /// </summary>
-        /// <returns></returns>
-        public string GetToken()
-        {
-            return _httpHelper.JWToken;
-        }
-
-        /// <summary>
-        /// Store Application Password in the Client
-        /// </summary>
-        /// <param name="applictionPassword"></param>
-        public void SetApplicationPassword(string applictionPassword)
-        {
-            _httpHelper.ApplicationPassword = applictionPassword;
-        }
-
-        #endregion auth methods
     }
 }

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -4,6 +4,70 @@
         <name>WordPressPCL</name>
     </assembly>
     <members>
+        <member name="T:WordPressPCL.Client.Auth">
+            <summary>
+            Client class for interaction with Auth endpoints of WP REST API
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Client.Auth.AuthMethod">
+            <summary>
+            Authentication Method
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Client.Auth._httpHelper">
+            <summary>
+            Helper for HTTP requests
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.#ctor(WordPressPCL.Utility.HttpHelper@)">
+            <summary>
+            Constructor
+            </summary>
+            <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.RequestJWTokenAsync(System.String,System.String)">
+            <summary>
+            Perform authentication by JWToken
+            </summary>
+            <param name="username">username</param>
+            <param name="Password">password</param>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.Logout">
+            <summary>
+            Forget the JWT Auth Token, won't invalidate it serverside though
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.IsValidJWTokenAsync">
+            <summary>
+            Check if token is valid
+            </summary>
+            <returns>Result of checking</returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.RemoveEmptyData(System.String)">
+            <summary>
+            Removes an empty data field in a Json string, e.g. when checking validity of token
+            </summary>
+            <param name="response">Json response input string</param>
+            <returns>Json response output string</returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.SetJWToken(System.String)">
+            <summary>
+            Sets an existing JWToken
+            </summary>
+            <param name="token"></param>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.GetToken">
+            <summary>
+            Gets the JWToken from the client
+            </summary>
+            <returns></returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.SetApplicationPassword(System.String)">
+            <summary>
+            Store Application Password in the Client
+            </summary>
+            <param name="applicationPassword"></param>
+        </member>
         <member name="T:WordPressPCL.Client.Categories">
             <summary>
             Client class for interaction with Categories endpoint WP REST API
@@ -4005,6 +4069,11 @@
             The username to be used with the Application Password
             </summary>
         </member>
+        <member name="P:WordPressPCL.WordPressClient.Auth">
+            <summary>
+            Auth client interaction object
+            </summary>
+        </member>
         <member name="P:WordPressPCL.WordPressClient.Posts">
             <summary>
             Posts client interaction object
@@ -4086,49 +4155,6 @@
             </summary>
             <param name="settings">Settings object</param>
             <returns>Updated settings</returns>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.RequestJWTokenAsync(System.String,System.String)">
-            <summary>
-            Perform authentication by JWToken
-            </summary>
-            <param name="Username">username</param>
-            <param name="Password">password</param>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.Logout">
-            <summary>
-            Forget the JWT Auth Token, won't invalidate it serverside though
-            </summary>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.IsValidJWTokenAsync">
-            <summary>
-            Check if token is valid
-            </summary>
-            <returns>Result of checking</returns>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.RemoveEmptyData(System.String)">
-            <summary>
-            Removes an empty data field in a Json string, e.g. when checking validity of token
-            </summary>
-            <param name="response">Json response input string</param>
-            <returns>Json response output string</returns>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.SetJWToken(System.String)">
-            <summary>
-            Sets an existing JWToken
-            </summary>
-            <param name="token"></param>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.GetToken">
-            <summary>
-            Gets the JWToken from the client
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:WordPressPCL.WordPressClient.SetApplicationPassword(System.String)">
-            <summary>
-            Store Application Password in the Client
-            </summary>
-            <param name="applictionPassword"></param>
         </member>
     </members>
 </doc>


### PR DESCRIPTION
Refactored `WordpressClient` to move the authentication functionality to a dedicated `Auth` sub client. For enhancement https://github.com/wp-net/WordPressPCL/issues/235