### PR TITLE
Auth Api Refactoring

### DIFF
--- a/WordPressPCL.Tests.Hosted/Utility/HttpHelper_Tests.cs
+++ b/WordPressPCL.Tests.Hosted/Utility/HttpHelper_Tests.cs
@@ -21,7 +21,7 @@ namespace WordPressPCL.Tests.Hosted.Utility
             // AUTHENTICATION DOES NOT YET WORK FOR HOSTED SITES
             var client = new WordPressClient(ApiCredentials.WordPressUri)
             {
-                AuthMethod = AuthMethod.JWT
+                AuthMethod = AuthMethod.Bearer
             };
             await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 
@@ -60,7 +60,7 @@ namespace WordPressPCL.Tests.Hosted.Utility
         {
             var client = new WordPressClient(ApiCredentials.WordPressUri)
             {
-                AuthMethod = AuthMethod.JWT
+                AuthMethod = AuthMethod.Bearer
             };
             await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 

--- a/WordPressPCL.Tests.Selfhosted/ApplicationPasswords_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/ApplicationPasswords_Tests.cs
@@ -55,7 +55,7 @@ namespace WordPressPCL.Tests.Selfhosted
             var appPassword = await _clientAuth.Users.CreateApplicationPasswordAsync(System.Guid.NewGuid().ToString());
             var appPasswordClient = new WordPressClient(ApiCredentials.WordPressUri)
             {
-                AuthMethod = AuthMethod.ApplicationPassword,
+                AuthMethod = AuthMethod.Basic,
                 UserName = ApiCredentials.Username
             };
             appPasswordClient.Auth.SetApplicationPassword(appPassword.Password);

--- a/WordPressPCL.Tests.Selfhosted/Basic_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Basic_Tests.cs
@@ -122,7 +122,7 @@ namespace WordPressPCL.Tests.Selfhosted
         {
             // TODO: this test fails on jwtauth in CICD
             // all other authorized calls are working though
-            if(_context?.Properties["authmode"]?.ToString() == "jwtauth")
+            if(_context?.Properties["authplugin"]?.ToString() == "jwtAuthByUsefulTeam")
             {
                 Assert.Inconclusive();
                 return;

--- a/WordPressPCL.Tests.Selfhosted/Utility/ClientHelper.cs
+++ b/WordPressPCL.Tests.Selfhosted/Utility/ClientHelper.cs
@@ -11,15 +11,16 @@ namespace WordPressPCL.Tests.Selfhosted.Utility
         public static async Task<WordPressClient> GetAuthenticatedWordPressClient(TestContext context)
         {
             var clientAuth = new WordPressClient(ApiCredentials.WordPressUri);
-
-            Console.WriteLine($"Auth Method: {context?.Properties["authmode"]}");
-            if (context?.Properties["authmode"]?.ToString() == "jwtauth")
+            clientAuth.AuthMethod = AuthMethod.Bearer;
+            
+            Console.WriteLine($"Auth Plugin: {context?.Properties["authplugin"]}");
+            if (context?.Properties["authplugin"]?.ToString() == "jwtAuthByUsefulTeam")
             {
-                clientAuth.AuthMethod = AuthMethod.JWTAuth;
+                clientAuth.JWTPlugin = JWTPlugin.JWTAuthByUsefulTeam;
             }
             else
             {
-                clientAuth.AuthMethod = AuthMethod.JWT;
+                clientAuth.JWTPlugin = JWTPlugin.JWTAuthByEnriqueChavez;
             }
             await clientAuth.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 

--- a/WordPressPCL.Tests.Selfhosted/jwt.runsettings
+++ b/WordPressPCL.Tests.Selfhosted/jwt.runsettings
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <TestRunParameters>
-    <Parameter name="authmode" value="jwt" />
+    <Parameter name="authplugin" value="jwtAuthByEnriqueChavez" />
     <Parameter name="skipapppassword" value="true"/>
   </TestRunParameters>
 </RunSettings>

--- a/WordPressPCL.Tests.Selfhosted/jwtauth.runsettings
+++ b/WordPressPCL.Tests.Selfhosted/jwtauth.runsettings
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <TestRunParameters>
-    <Parameter name="authmode" value="jwtauth" />
+    <Parameter name="authplugin" value="jwtAuthByUsefulTeam" />
     <Parameter name="skipapppassword" value="true"/>
   </TestRunParameters>
 </RunSettings>

--- a/WordPressPCL/Client/Auth.cs
+++ b/WordPressPCL/Client/Auth.cs
@@ -24,6 +24,11 @@ namespace WordPressPCL.Client {
         internal AuthMethod AuthMethod { get; set; }
 
         /// <summary>
+        /// JWT Plugin
+        /// </summary>
+        internal JWTPlugin JWTPlugin { get; set; }
+
+        /// <summary>
         /// Helper for HTTP requests
         /// </summary>
         private readonly HttpHelper _httpHelper;
@@ -49,10 +54,10 @@ namespace WordPressPCL.Client {
                     new KeyValuePair<string, string>("username", username),
                     new KeyValuePair<string, string>("password", Password)
                 });
-            if (AuthMethod == AuthMethod.JWT) {
+            if (JWTPlugin == JWTPlugin.JWTAuthByEnriqueChavez) {
                 (JWTUser jwtUser, _) = await _httpHelper.PostRequestAsync<JWTUser>(route, formContent, false).ConfigureAwait(false);
                 _httpHelper.JWToken = jwtUser?.Token;
-            } else if (AuthMethod == AuthMethod.JWTAuth) {
+            } else if (JWTPlugin == JWTPlugin.JWTAuthByUsefulTeam) {
                 _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
                 (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, formContent, false).ConfigureAwait(false);
                 _httpHelper.HttpResponsePreProcessing = null;
@@ -77,10 +82,10 @@ namespace WordPressPCL.Client {
         public async Task<bool> IsValidJWTokenAsync() {
             var route = $"{JwtPath}token/validate";
             try {
-                if (AuthMethod == AuthMethod.JWT) {
+                if (JWTPlugin == JWTPlugin.JWTAuthByEnriqueChavez) {
                     (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequestAsync<JWTUser>(route, null, true).ConfigureAwait(false);
                     return repsonse.IsSuccessStatusCode;
-                } else if (AuthMethod == AuthMethod.JWTAuth) {
+                } else if (JWTPlugin == JWTPlugin.JWTAuthByUsefulTeam) {
                     _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
                     (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, null, true).ConfigureAwait(false);
                     _httpHelper.HttpResponsePreProcessing = null;

--- a/WordPressPCL/Models/AuthMethod.cs
+++ b/WordPressPCL/Models/AuthMethod.cs
@@ -7,16 +7,12 @@
     public enum AuthMethod
     {
         /// <summary>
-        /// JSON Web Token Authentication method by Enrique Chavez. Need configure your site with this plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
+        /// Bearer Authentication using token
         /// </summary>
-        JWT,
+        Bearer,
         /// <summary>
-        /// JSON Web Token Authentication method by Useful Team. Need configure your site with this plugin https://wordpress.org/plugins/jwt-auth/
+        /// Basic Authentication using Application Passwords introduced in Wordpress 5.6
         /// </summary>
-        JWTAuth,
-        /// <summary>
-        /// Basic authentication using Application Passwords introduced in WordPress 5.6
-        /// </summary>
-        ApplicationPassword
+        Basic
     }
 }

--- a/WordPressPCL/Models/JWTPlugin.cs
+++ b/WordPressPCL/Models/JWTPlugin.cs
@@ -1,0 +1,20 @@
+namespace WordPressPCL.Models {
+    
+    /// <summary>
+    /// JWT Plugins supported
+    /// </summary>
+    public enum JWTPlugin {
+        
+        /// <summary>
+        /// JWT Authentication for WP REST API plugin
+        /// Author - Enrique Chavez
+        /// </summary>
+        JWTAuthByEnriqueChavez,
+        /// <summary>
+        /// JWT Auth – WordPress JSON Web Token Authentication plugin
+        /// Author - Useful Team
+        /// </summary>
+        JWTAuthByUsefulTeam
+        
+    }
+}

--- a/WordPressPCL/Utility/HttpHelper.cs
+++ b/WordPressPCL/Utility/HttpHelper.cs
@@ -173,11 +173,11 @@ namespace WordPressPCL.Utility
         {
             if (isAuthRequired)
             {
-                if (AuthMethod == AuthMethod.JWT || AuthMethod == AuthMethod.JWTAuth)
+                if(AuthMethod == AuthMethod.Bearer)
                 {
                     requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", JWToken);
                 }
-                else if (AuthMethod == AuthMethod.ApplicationPassword)
+                else if (AuthMethod == AuthMethod.Basic)
                 {
                     var authToken = Encoding.ASCII.GetBytes($"{UserName}:{ApplicationPassword}");
                     requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authToken));

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -66,6 +66,15 @@ namespace WordPressPCL
         }
 
         /// <summary>
+        /// JWTAuth Plugin
+        /// </summary>
+        public JWTPlugin JWTPlugin 
+        {
+            get => Auth.JWTPlugin;
+            set => Auth.JWTPlugin = value;
+        }
+
+        /// <summary>
         /// The username to be used with the Application Password
         /// </summary>
         public string UserName {

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -14,6 +14,11 @@
             Authentication Method
             </summary>
         </member>
+        <member name="P:WordPressPCL.Client.Auth.JWTPlugin">
+            <summary>
+            JWT Plugin
+            </summary>
+        </member>
         <member name="F:WordPressPCL.Client.Auth._httpHelper">
             <summary>
             Helper for HTTP requests
@@ -854,19 +859,14 @@
             <para> JWT - recommended AUTH method</para>
             </summary>
         </member>
-        <member name="F:WordPressPCL.Models.AuthMethod.JWT">
+        <member name="F:WordPressPCL.Models.AuthMethod.Bearer">
             <summary>
-            JSON Web Token Authentication method by Enrique Chavez. Need configure your site with this plugin https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/
+            Bearer Authentication using token
             </summary>
         </member>
-        <member name="F:WordPressPCL.Models.AuthMethod.JWTAuth">
+        <member name="F:WordPressPCL.Models.AuthMethod.Basic">
             <summary>
-            JSON Web Token Authentication method by Useful Team. Need configure your site with this plugin https://wordpress.org/plugins/jwt-auth/
-            </summary>
-        </member>
-        <member name="F:WordPressPCL.Models.AuthMethod.ApplicationPassword">
-            <summary>
-            Basic authentication using Application Passwords introduced in WordPress 5.6
+            Basic Authentication using Application Passwords introduced in Wordpress 5.6
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.AvatarURL">
@@ -1741,6 +1741,23 @@
         <member name="P:WordPressPCL.Models.JWTData.NiceName">
             <summary>
             User Nice Names
+            </summary>
+        </member>
+        <member name="T:WordPressPCL.Models.JWTPlugin">
+            <summary>
+            JWT Plugins supported
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.JWTPlugin.JWTAuthByEnriqueChavez">
+            <summary>
+            JWT Authentication for WP REST API plugin
+            Author - Enrique Chavez
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.JWTPlugin.JWTAuthByUsefulTeam">
+            <summary>
+            JWT Auth – WordPress JSON Web Token Authentication plugin
+            Author - Useful Team
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.JWTResponse">
@@ -4062,6 +4079,11 @@
         <member name="P:WordPressPCL.WordPressClient.AuthMethod">
             <summary>
             Authentication method
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.WordPressClient.JWTPlugin">
+            <summary>
+            JWTAuth Plugin
             </summary>
         </member>
         <member name="P:WordPressPCL.WordPressClient.UserName">


### PR DESCRIPTION
Refactored the Auth api to change the `AuthMethod` to have more descriptive auth methods of `Basic` and `Bearer`
Added a new Enum `JWTPlugin` which give descriptive names to the Wordpress plugin by the name of the author of plugin
The method signatures for Auth are same as the previous implementation of the library
The default selection for the Auth method is `Bearer` which was previously `JWT` (plugin by Enrique Chavez)
The default selection for the JWT plugin is Enrique Chavez auth plugin - same as the previous implementation.
There is an additional property on `WorpdressClient` which is `JWTPlugin`. So, the configuration can be compared as:

```
//previous configuration
var client = new WordpressClient(wordpressUri) {
    AuthMethod = AuthMethod.JWT
};

//new configuration
var client = new WordpressClient(wordpressUri) {
    AuthMethod = AuthMethod.Bearer,
    JWTPlugin = JWTPlugin.JWTAuthByEnriqueChavez
}

//new configuration will default to Enrique Chavez's plugin
//this will behave as the previous configuration
var client = new WordpressClient(wordpressUri) {
    AuthMethod = AuthMethod.Bearer
}
```

This PR doesn't include the changes for general JWT auth plugin. I will include it in another PR because that will be an add-on rather than a refactoring.