### PR TITLE
Feature to give the count of total posts without actually retrieving them

### DIFF
--- a/WordPressPCL.Tests.Selfhosted/Posts_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Posts_Tests.cs
@@ -65,6 +65,13 @@ namespace WordPressPCL.Tests.Selfhosted
         }
 
         [TestMethod]
+        public async Task Posts_Count_Should_Equal_Number_Of_Posts() {
+            var posts = await _client.Posts.GetAllAsync();
+            var postsCount = await _client.Posts.GetCountAsync();
+            Assert.AreEqual(posts.Count(), postsCount);
+        }
+
+        [TestMethod]
         public async Task Posts_Read_Embedded()
         {
             var posts = await _client.Posts.QueryAsync(new PostsQueryBuilder()

--- a/WordPressPCL/Client/Posts.cs
+++ b/WordPressPCL/Client/Posts.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
+using WordPressPCL.Interfaces;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;
 
@@ -9,7 +11,7 @@ namespace WordPressPCL.Client
     /// <summary>
     /// Client class for interaction with Posts endpoint WP REST API
     /// </summary>
-    public class Posts : CRUDOperation<Post, PostsQueryBuilder>
+    public class Posts : CRUDOperation<Post, PostsQueryBuilder>, ICountOperation
     {
         #region Init
 
@@ -95,6 +97,17 @@ namespace WordPressPCL.Client
             // default values
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
             return HttpHelper.GetRequestAsync<IEnumerable<Post>>($"{DefaultPath}{_methodPath}?search={searchTerm}", embed, useAuth);
+        }
+
+        /// <summary>
+        /// Get count of posts
+        /// </summary>
+        /// <returns>Result of operation</returns>
+        public async Task<int> GetCountAsync() 
+        {
+            var responseHeaders = await HttpHelper.HeadRequestAsync($"{DefaultPath}{_methodPath}").ConfigureAwait(false);
+            var totalHeaderVal = responseHeaders.GetValues("X-WP-Total").First();
+            return int.Parse(totalHeaderVal, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/WordPressPCL/Interfaces/ICountOperation.cs
+++ b/WordPressPCL/Interfaces/ICountOperation.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace WordPressPCL.Interfaces {
+
+    /// <summary>
+    /// Interface for count of Wordpress items
+    /// </summary>
+    public interface ICountOperation
+    {
+        /// <summary>
+        /// Get Count of Wordpress items
+        /// </summary>
+        /// <returns>Result of Operation</returns>
+        Task<int> GetCountAsync();
+    }
+}

--- a/WordPressPCL/Utility/HttpHelper.cs
+++ b/WordPressPCL/Utility/HttpHelper.cs
@@ -169,6 +169,24 @@ namespace WordPressPCL.Utility
             }
         }
 
+        internal async Task<HttpResponseHeaders> HeadRequestAsync(string route, bool isAuthRequired = false) 
+        {
+            HttpResponseMessage response;
+            using (var requestMessage = new HttpRequestMessage(HttpMethod.Head, $"{_wordpressURI}{route}")) 
+            {
+                SetAuthHeader(isAuthRequired, requestMessage);
+                response = await _httpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            }
+
+            LastResponseHeaders = response.Headers;
+            if (response.IsSuccessStatusCode) 
+            {
+                return response.Headers;
+            }
+
+            throw new WPUnexpectedException(response, string.Empty);
+        }
+
         private void SetAuthHeader(bool isAuthRequired, HttpRequestMessage requestMessage)
         {
             if (isAuthRequired)

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -482,6 +482,12 @@
             <param name="useAuth">Send request with authentication header</param>
             <returns>List of posts</returns>
         </member>
+        <member name="M:WordPressPCL.Client.Posts.GetCountAsync">
+            <summary>
+            Get count of posts
+            </summary>
+            <returns>Result of operation</returns>
+        </member>
         <member name="M:WordPressPCL.Client.Posts.Delete(System.Int32,System.Boolean)">
             <summary>
             Delete post with force deletion
@@ -723,6 +729,17 @@
             </summary>
             <param name="userId">User ID, defaults to "me"</param>
             <returns>List of registered Application Passwords (without the actual password)</returns>
+        </member>
+        <member name="T:WordPressPCL.Interfaces.ICountOperation">
+            <summary>
+            Interface for count of Wordpress items
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Interfaces.ICountOperation.GetCountAsync">
+            <summary>
+            Get Count of Wordpress items
+            </summary>
+            <returns>Result of Operation</returns>
         </member>
         <member name="T:WordPressPCL.Interfaces.ICreateOperation`1">
             <summary>


### PR DESCRIPTION
Added the feature to give count of total posts without loading all of them in memory.

A `HEAD` request is made to the WordPress REST API which gives back all the headers without any response payload. Then the value of `X-WP-TOTAL` header is returned.

This PR is a minimal solution to https://github.com/wp-net/WordPressPCL/issues/255