### PR TITLE
GetAllAsync Bugfix & ref removal

### DIFF
--- a/WordPressPCL.Tests.Selfhosted/Posts_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Posts_Tests.cs
@@ -66,6 +66,19 @@ namespace WordPressPCL.Tests.Selfhosted
 
         [TestMethod]
         public async Task Posts_Count_Should_Equal_Number_Of_Posts() {
+            // Create 100+ posts to test multi-page GetAll
+            var postsCreate = Enumerable.Range(0, 110).Select(x => 
+                new Post()
+                {
+                    Title = new Title($"{System.Guid.NewGuid()} {x}"),
+                    Content = new Content("Content PostCreate")
+                }
+            ).ToList();
+            foreach(var post in postsCreate)
+            {
+                var createdPost = await _clientAuth.Posts.CreateAsync(post);
+            }
+
             var posts = await _client.Posts.GetAllAsync();
             var postsCount = await _client.Posts.GetCountAsync();
             Assert.AreEqual(posts.Count(), postsCount);

--- a/WordPressPCL/Client/Auth.cs
+++ b/WordPressPCL/Client/Auth.cs
@@ -37,7 +37,7 @@ namespace WordPressPCL.Client {
         /// Constructor
         /// </summary>
         /// <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Auth(ref HttpHelper httpHelper) 
+        public Auth(HttpHelper httpHelper) 
         {
             _httpHelper = httpHelper;
         }

--- a/WordPressPCL/Client/CRUDOperation.cs
+++ b/WordPressPCL/Client/CRUDOperation.cs
@@ -49,7 +49,7 @@ namespace WordPressPCL.Client
         /// <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
         /// <param name="methodPath">path to endpoint, EX. posts</param>
         /// <param name="forceDeletion">is objects must be force deleted</param>
-        protected CRUDOperation(ref HttpHelper httpHelper, string methodPath, bool forceDeletion = false)
+        protected CRUDOperation(HttpHelper httpHelper, string methodPath, bool forceDeletion = false)
         {
             HttpHelper = httpHelper;
             MethodPath = methodPath;
@@ -106,7 +106,7 @@ namespace WordPressPCL.Client
                 int totalpages = Convert.ToInt32(HttpHelper.LastResponseHeaders.GetValues("X-WP-TotalPages").FirstOrDefault(), CultureInfo.InvariantCulture);
                 for (int page = 2; page <= totalpages; page++)
                 {
-                    url = MethodPath.SetQueryParam("per_page", page.ToString()).SetQueryParam("page", "1");
+                    url = MethodPath.SetQueryParam("per_page","100").SetQueryParam("page", page.ToString());
                     entities.AddRange((await HttpHelper.GetRequestAsync<IEnumerable<TClass>>(url, embed, useAuth).ConfigureAwait(false))?.ToList());
                 }
             }

--- a/WordPressPCL/Client/Categories.cs
+++ b/WordPressPCL/Client/Categories.cs
@@ -16,7 +16,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Categories(ref HttpHelper HttpHelper) : base(ref HttpHelper, _methodPath, true)
+        public Categories(HttpHelper HttpHelper) : base(HttpHelper, _methodPath, true)
         {
         }
 

--- a/WordPressPCL/Client/Comments.cs
+++ b/WordPressPCL/Client/Comments.cs
@@ -21,7 +21,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Comments(ref HttpHelper HttpHelper) : base(ref HttpHelper, _methodPath)
+        public Comments(HttpHelper HttpHelper) : base(HttpHelper, _methodPath)
         {
         }
 

--- a/WordPressPCL/Client/CustomRequest.cs
+++ b/WordPressPCL/Client/CustomRequest.cs
@@ -17,7 +17,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="httpHelper">HttpHelper class to operate with Http methods</param>
-        public CustomRequest(ref HttpHelper httpHelper)
+        public CustomRequest(HttpHelper httpHelper)
         {
             _httpHelper = httpHelper;
         }

--- a/WordPressPCL/Client/Media.cs
+++ b/WordPressPCL/Client/Media.cs
@@ -27,7 +27,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Media(ref HttpHelper HttpHelper)
+        public Media(HttpHelper HttpHelper)
         {
             _httpHelper = HttpHelper;
         }

--- a/WordPressPCL/Client/Pages.cs
+++ b/WordPressPCL/Client/Pages.cs
@@ -19,7 +19,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Pages(ref HttpHelper HttpHelper) : base(ref HttpHelper, _methodPath)
+        public Pages(HttpHelper HttpHelper) : base(HttpHelper, _methodPath)
         {
         }
 

--- a/WordPressPCL/Client/PostStatuses.cs
+++ b/WordPressPCL/Client/PostStatuses.cs
@@ -18,7 +18,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public PostStatuses(ref HttpHelper httpHelper)
+        public PostStatuses(HttpHelper httpHelper)
         {
             _httpHelper = httpHelper;
         }

--- a/WordPressPCL/Client/PostTypes.cs
+++ b/WordPressPCL/Client/PostTypes.cs
@@ -18,7 +18,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public PostTypes(ref HttpHelper httpHelper)
+        public PostTypes(HttpHelper httpHelper)
         {
             _httpHelper = httpHelper;
         }

--- a/WordPressPCL/Client/Posts.cs
+++ b/WordPressPCL/Client/Posts.cs
@@ -21,7 +21,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Posts(ref HttpHelper HttpHelper) : base(ref HttpHelper, _methodPath)
+        public Posts(HttpHelper HttpHelper) : base(HttpHelper, _methodPath)
         {
         }
 

--- a/WordPressPCL/Client/Tags.cs
+++ b/WordPressPCL/Client/Tags.cs
@@ -16,7 +16,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Tags(ref HttpHelper HttpHelper) : base(ref HttpHelper, _methodPath, true)
+        public Tags(HttpHelper HttpHelper) : base(HttpHelper, _methodPath, true)
         {
         }
 

--- a/WordPressPCL/Client/Taxonomies.cs
+++ b/WordPressPCL/Client/Taxonomies.cs
@@ -18,7 +18,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Taxonomies(ref HttpHelper httpHelper)
+        public Taxonomies(HttpHelper httpHelper)
         {
             _httpHelper = httpHelper;
         }

--- a/WordPressPCL/Client/Users.cs
+++ b/WordPressPCL/Client/Users.cs
@@ -27,7 +27,7 @@ namespace WordPressPCL.Client
         /// Constructor
         /// </summary>
         /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
-        public Users(ref HttpHelper HttpHelper)
+        public Users(HttpHelper HttpHelper)
         {
             _httpHelper = HttpHelper;
         }

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -146,18 +146,18 @@ namespace WordPressPCL
             WordPressUri = uri ?? throw new ArgumentNullException(nameof(uri));
 
             _httpHelper = new HttpHelper(WordPressUri, defaultPath);
-            Auth = new Auth(ref _httpHelper);
-            Posts = new Posts(ref _httpHelper);
-            Comments = new Comments(ref _httpHelper);
-            Tags = new Tags(ref _httpHelper);
-            Users = new Users(ref _httpHelper);
-            Media = new Media(ref _httpHelper);
-            Categories = new Categories(ref _httpHelper);
-            Pages = new Pages(ref _httpHelper);
-            Taxonomies = new Taxonomies(ref _httpHelper);
-            PostTypes = new PostTypes(ref _httpHelper);
-            PostStatuses = new PostStatuses(ref _httpHelper);
-            CustomRequest = new CustomRequest(ref _httpHelper);
+            Auth = new Auth(_httpHelper);
+            Posts = new Posts(_httpHelper);
+            Comments = new Comments(_httpHelper);
+            Tags = new Tags(_httpHelper);
+            Users = new Users(_httpHelper);
+            Media = new Media(_httpHelper);
+            Categories = new Categories(_httpHelper);
+            Pages = new Pages(_httpHelper);
+            Taxonomies = new Taxonomies(_httpHelper);
+            PostTypes = new PostTypes(_httpHelper);
+            PostStatuses = new PostStatuses(_httpHelper);
+            CustomRequest = new CustomRequest(_httpHelper);
         }
 
         /// <summary>
@@ -185,18 +185,18 @@ namespace WordPressPCL
             WordPressUri = httpClient.BaseAddress;
 
             _httpHelper = new HttpHelper(httpClient, defaultPath);
-            Auth = new Auth(ref _httpHelper);
-            Posts = new Posts(ref _httpHelper);
-            Comments = new Comments(ref _httpHelper);
-            Tags = new Tags(ref _httpHelper);
-            Users = new Users(ref _httpHelper);
-            Media = new Media(ref _httpHelper);
-            Categories = new Categories(ref _httpHelper);
-            Pages = new Pages(ref _httpHelper);
-            Taxonomies = new Taxonomies(ref _httpHelper);
-            PostTypes = new PostTypes(ref _httpHelper);
-            PostStatuses = new PostStatuses(ref _httpHelper);
-            CustomRequest = new CustomRequest(ref _httpHelper);
+            Auth = new Auth(_httpHelper);
+            Posts = new Posts(_httpHelper);
+            Comments = new Comments(_httpHelper);
+            Tags = new Tags(_httpHelper);
+            Users = new Users(_httpHelper);
+            Media = new Media(_httpHelper);
+            Categories = new Categories(_httpHelper);
+            Pages = new Pages(_httpHelper);
+            Taxonomies = new Taxonomies(_httpHelper);
+            PostTypes = new PostTypes(_httpHelper);
+            PostStatuses = new PostStatuses(_httpHelper);
+            CustomRequest = new CustomRequest(_httpHelper);
         }
 
         #region Settings methods

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -78,63 +78,63 @@ namespace WordPressPCL
         /// <summary>
         /// Auth client interaction object
         /// </summary>
-        public Auth Auth { get; }
+        public Auth Auth { get; private set; }
 
         //public string JWToken;
         /// <summary>
         /// Posts client interaction object
         /// </summary>
-        public Posts Posts { get; }
+        public Posts Posts { get; private set; }
 
         /// <summary>
         /// Comments client interaction object
         /// </summary>
-        public Comments Comments { get; }
+        public Comments Comments { get; private set; }
 
         /// <summary>
         /// Tags client interaction object
         /// </summary>
-        public Tags Tags { get; }
+        public Tags Tags { get; private set; }
 
         /// <summary>
         /// Users client interaction object
         /// </summary>
-        public Users Users { get; }
+        public Users Users { get; private set; }
 
         /// <summary>
         /// Media client interaction object
         /// </summary>
-        public Media Media { get; }
+        public Media Media { get; private set; }
 
         /// <summary>
         /// Categories client interaction object
         /// </summary>
-        public Categories Categories { get; }
+        public Categories Categories { get; private set; }
 
         /// <summary>
         /// Pages client interaction object
         /// </summary>
-        public Pages Pages { get; }
+        public Pages Pages { get; private set; }
 
         /// <summary>
         /// Taxonomies client interaction object
         /// </summary>
-        public Taxonomies Taxonomies { get; }
+        public Taxonomies Taxonomies { get; private set; }
 
         /// <summary>
         /// Post Types client interaction object
         /// </summary>
-        public PostTypes PostTypes { get; }
+        public PostTypes PostTypes { get; private set; }
 
         /// <summary>
         /// Post Statuses client interaction object
         /// </summary>
-        public PostStatuses PostStatuses { get; }
+        public PostStatuses PostStatuses { get; private set; }
 
         /// <summary>
         /// Custom Request client interaction object
         /// </summary>
-        public CustomRequest CustomRequest { get; }
+        public CustomRequest CustomRequest { get; private set; }
 
         /// <summary>
         /// The WordPressClient holds all connection infos and provides methods to call WordPress APIs.
@@ -144,20 +144,8 @@ namespace WordPressPCL
         public WordPressClient(Uri uri, string defaultPath = DEFAULT_PATH)
         {
             WordPressUri = uri ?? throw new ArgumentNullException(nameof(uri));
-
             _httpHelper = new HttpHelper(WordPressUri, defaultPath);
-            Auth = new Auth(_httpHelper);
-            Posts = new Posts(_httpHelper);
-            Comments = new Comments(_httpHelper);
-            Tags = new Tags(_httpHelper);
-            Users = new Users(_httpHelper);
-            Media = new Media(_httpHelper);
-            Categories = new Categories(_httpHelper);
-            Pages = new Pages(_httpHelper);
-            Taxonomies = new Taxonomies(_httpHelper);
-            PostTypes = new PostTypes(_httpHelper);
-            PostStatuses = new PostStatuses(_httpHelper);
-            CustomRequest = new CustomRequest(_httpHelper);
+            SetupSubClients(_httpHelper);
         }
 
         /// <summary>
@@ -181,22 +169,25 @@ namespace WordPressPCL
             {
                 throw new ArgumentNullException(nameof(httpClient));
             }
-
             WordPressUri = httpClient.BaseAddress;
-
             _httpHelper = new HttpHelper(httpClient, defaultPath);
-            Auth = new Auth(_httpHelper);
-            Posts = new Posts(_httpHelper);
-            Comments = new Comments(_httpHelper);
-            Tags = new Tags(_httpHelper);
-            Users = new Users(_httpHelper);
-            Media = new Media(_httpHelper);
-            Categories = new Categories(_httpHelper);
-            Pages = new Pages(_httpHelper);
-            Taxonomies = new Taxonomies(_httpHelper);
-            PostTypes = new PostTypes(_httpHelper);
-            PostStatuses = new PostStatuses(_httpHelper);
-            CustomRequest = new CustomRequest(_httpHelper);
+            SetupSubClients(_httpHelper);
+        }
+
+        private void SetupSubClients(HttpHelper httpHelper)
+        {
+            Auth = new Auth(httpHelper);
+            Posts = new Posts(httpHelper);
+            Comments = new Comments(httpHelper);
+            Tags = new Tags(httpHelper);
+            Users = new Users(httpHelper);
+            Media = new Media(httpHelper);
+            Categories = new Categories(httpHelper);
+            Pages = new Pages(httpHelper);
+            Taxonomies = new Taxonomies(httpHelper);
+            PostTypes = new PostTypes(httpHelper);
+            PostStatuses = new PostStatuses(httpHelper);
+            CustomRequest = new CustomRequest(httpHelper);
         }
 
         #region Settings methods

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -24,7 +24,7 @@
             Helper for HTTP requests
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Auth.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Auth.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -78,7 +78,7 @@
             Client class for interaction with Categories endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Categories.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Categories.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -89,7 +89,7 @@
             Client class for interaction with Comments endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Comments.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Comments.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -148,7 +148,7 @@
             Is object must be force deleted
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.CRUDOperation`2.#ctor(WordPressPCL.Utility.HttpHelper@,System.String,System.Boolean)">
+        <member name="M:WordPressPCL.Client.CRUDOperation`2.#ctor(WordPressPCL.Utility.HttpHelper,System.String,System.Boolean)">
             <summary>
             Constructor
             </summary>
@@ -215,7 +215,7 @@
             Class to create custom requests
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.CustomRequest.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.CustomRequest.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -263,7 +263,7 @@
             Client class for interaction with Media endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Media.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Media.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -339,7 +339,7 @@
             Client class for interaction with Pages endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Pages.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Pages.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -420,7 +420,7 @@
             Client class for interaction with Posts endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Posts.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Posts.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -496,7 +496,7 @@
             Client class for interaction with Post Types endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.PostStatuses.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.PostStatuses.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -532,7 +532,7 @@
             Client class for interaction with Post Types endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.PostTypes.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.PostTypes.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -568,7 +568,7 @@
             Client class for interaction with Tags endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Tags.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Tags.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -579,7 +579,7 @@
             Client class for interaction with Taxonomies endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Taxonomies.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Taxonomies.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>
@@ -623,7 +623,7 @@
             Client class for interaction with Users endpoint WP REST API
             </summary>
         </member>
-        <member name="M:WordPressPCL.Client.Users.#ctor(WordPressPCL.Utility.HttpHelper@)">
+        <member name="M:WordPressPCL.Client.Users.#ctor(WordPressPCL.Utility.HttpHelper)">
             <summary>
             Constructor
             </summary>


### PR DESCRIPTION
I've re-evaluated the ref construct for passing the HttpHelper to all sub-clients and didn't find a reason to keep it. 
This also allowed me to do all the SubClient initialization in a separate method to remove code duplication.

When testing this I also encountered a serious bug with the GetAllAsync method that doesn't work properly with 102+ items.

@navjot50 any thoughts or concerns?