### PR TITLE
Refactoring #291

### DIFF
--- a/WordPressPCL.Tests.Hosted/Utility/HttpHelper_Tests.cs
+++ b/WordPressPCL.Tests.Hosted/Utility/HttpHelper_Tests.cs
@@ -19,10 +19,8 @@ namespace WordPressPCL.Tests.Hosted.Utility
         public async Task Hosted_HttpHelper_InvalidPreProcessing()
         {
             // AUTHENTICATION DOES NOT YET WORK FOR HOSTED SITES
-            var client = new WordPressClient(ApiCredentials.WordPressUri)
-            {
-                AuthMethod = AuthMethod.Bearer
-            };
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            client.Auth.UseBearerAuth(JWTPlugin.JWTAuthByEnriqueChavez);
             await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 
             // Create a random tag , must works:
@@ -56,12 +54,9 @@ namespace WordPressPCL.Tests.Hosted.Utility
         }
 
         [TestMethod]
-        public async Task Hosted_HttpHelper_ValidPreProcessing()
-        {
-            var client = new WordPressClient(ApiCredentials.WordPressUri)
-            {
-                AuthMethod = AuthMethod.Bearer
-            };
+        public async Task Hosted_HttpHelper_ValidPreProcessing() {
+            var client = new WordPressClient(ApiCredentials.WordPressUri);
+            client.Auth.UseBearerAuth(JWTPlugin.JWTAuthByEnriqueChavez);
             await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 
             // Create a random tag

--- a/WordPressPCL.Tests.Selfhosted/ApplicationPasswords_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/ApplicationPasswords_Tests.cs
@@ -53,12 +53,8 @@ namespace WordPressPCL.Tests.Selfhosted
             }
             Console.WriteLine("Run App Password Test");
             var appPassword = await _clientAuth.Users.CreateApplicationPasswordAsync(System.Guid.NewGuid().ToString());
-            var appPasswordClient = new WordPressClient(ApiCredentials.WordPressUri)
-            {
-                AuthMethod = AuthMethod.Basic,
-                UserName = ApiCredentials.Username
-            };
-            appPasswordClient.Auth.SetApplicationPassword(appPassword.Password);
+            var appPasswordClient = new WordPressClient(ApiCredentials.WordPressUri);
+            appPasswordClient.Auth.UseBasicAuth(ApiCredentials.Username, appPassword.Password);
 
             var post = new Post()
             {

--- a/WordPressPCL.Tests.Selfhosted/ExceptionTests.cs
+++ b/WordPressPCL.Tests.Selfhosted/ExceptionTests.cs
@@ -33,6 +33,37 @@ namespace WordPressPCL.Tests.Selfhosted
         }
 
         [TestMethod]
+        public async Task Exception_RequestJWTokenForBasicAuth() 
+        {
+            //Initialize
+            Assert.IsNotNull(_client);
+            const string dummyUser = "dummy";
+            const string dummyPassword = "dummy";
+            
+            _client.Auth.UseBasicAuth(dummyUser, dummyPassword);
+            
+            await Assert.ThrowsExceptionAsync<WPException>(async () => 
+            {
+                await _client.Auth.RequestJWTokenAsync(dummyUser, dummyPassword);
+            });
+        }
+
+        [TestMethod]
+        public async Task Exception_IsValidJWTokenForBasicAuth() 
+        {
+            //Initialize
+            Assert.IsNotNull(_client);
+            const string dummyUser = "dummy";
+            const string dummyPassword = "dummy";
+            
+            _client.Auth.UseBasicAuth(dummyUser, dummyPassword);
+
+            await Assert.ThrowsExceptionAsync<WPException>(async () => {
+                await _client.Auth.IsValidJWTokenAsync();
+            });
+        }
+
+        [TestMethod]
         public async Task Exception_PostCreateExceptionTest()
         {
             // Initialize

--- a/WordPressPCL.Tests.Selfhosted/Utility/ClientHelper.cs
+++ b/WordPressPCL.Tests.Selfhosted/Utility/ClientHelper.cs
@@ -11,16 +11,14 @@ namespace WordPressPCL.Tests.Selfhosted.Utility
         public static async Task<WordPressClient> GetAuthenticatedWordPressClient(TestContext context)
         {
             var clientAuth = new WordPressClient(ApiCredentials.WordPressUri);
-            clientAuth.AuthMethod = AuthMethod.Bearer;
-            
+
             Console.WriteLine($"Auth Plugin: {context?.Properties["authplugin"]}");
             if (context?.Properties["authplugin"]?.ToString() == "jwtAuthByUsefulTeam")
             {
-                clientAuth.JWTPlugin = JWTPlugin.JWTAuthByUsefulTeam;
+                clientAuth.Auth.UseBearerAuth(JWTPlugin.JWTAuthByUsefulTeam);
             }
-            else
-            {
-                clientAuth.JWTPlugin = JWTPlugin.JWTAuthByEnriqueChavez;
+            else {
+                clientAuth.Auth.UseBearerAuth(JWTPlugin.JWTAuthByEnriqueChavez);
             }
             await clientAuth.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
 

--- a/WordPressPCL/Client/Auth.cs
+++ b/WordPressPCL/Client/Auth.cs
@@ -21,12 +21,17 @@ namespace WordPressPCL.Client {
         /// <summary>
         /// Authentication Method
         /// </summary>
-        internal AuthMethod AuthMethod { get; set; }
+        public AuthMethod AuthMethod { get; private set; } = AuthMethod.Bearer;
 
         /// <summary>
         /// JWT Plugin
         /// </summary>
-        internal JWTPlugin JWTPlugin { get; set; }
+        public JWTPlugin JWTPlugin { get; private set; } = JWTPlugin.JWTAuthByEnriqueChavez;
+
+        /// <summary>
+        /// Username for Basic Authentication
+        /// </summary>
+        public string Username { get; private set; } = string.Empty;
 
         /// <summary>
         /// Helper for HTTP requests
@@ -43,27 +48,60 @@ namespace WordPressPCL.Client {
         }
 
         /// <summary>
+        /// Sets up the Auth Client to use Bearer Authentication with specified JWTPlugin
+        /// </summary>
+        /// <param name="jwtPlugin">JWT Plugin to use for Bearer Authentication</param>
+        public void UseBearerAuth(JWTPlugin jwtPlugin) 
+        {
+            AuthMethod = AuthMethod.Bearer;
+            JWTPlugin = jwtPlugin;
+            _httpHelper.AuthMethod = AuthMethod.Bearer;
+        }
+
+        /// <summary>
+        /// Sets up the Auth Client to use Basic Authentication with Application Password
+        /// </summary>
+        /// <param name="username">Username for Basic Authentication</param>
+        /// <param name="applicationPassword">Application Password for Basic Authentication</param>
+        public void UseBasicAuth(string username, string applicationPassword) 
+        {
+            AuthMethod = AuthMethod.Basic;
+            Username = username;
+            _httpHelper.AuthMethod = AuthMethod.Basic;
+            _httpHelper.UserName = username;
+            _httpHelper.ApplicationPassword = applicationPassword;
+        }
+
+        /// <summary>
         /// Perform authentication by JWToken
         /// </summary>
         /// <param name="username">username</param>
-        /// <param name="Password">password</param>
-        public async Task RequestJWTokenAsync(string username, string Password) {
+        /// <param name="password">password</param>
+        public async Task RequestJWTokenAsync(string username, string password) {
+            if (AuthMethod == AuthMethod.Basic) {
+                throw new WPException("Cannot request JWToken with Basic Authentication");
+            }
+
             var route = $"{JwtPath}token";
             using var formContent = new FormUrlEncodedContent(new[]
-                {
+            {
                     new KeyValuePair<string, string>("username", username),
-                    new KeyValuePair<string, string>("password", Password)
-                });
-            if (JWTPlugin == JWTPlugin.JWTAuthByEnriqueChavez) {
-                (JWTUser jwtUser, _) = await _httpHelper.PostRequestAsync<JWTUser>(route, formContent, isAuthRequired: false, ignoreDefaultPath: true).ConfigureAwait(false);
-                _httpHelper.JWToken = jwtUser?.Token;
-            } else if (JWTPlugin == JWTPlugin.JWTAuthByUsefulTeam) {
-                _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
-                (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, formContent, isAuthRequired: false, ignoreDefaultPath: true).ConfigureAwait(false);
-                _httpHelper.HttpResponsePreProcessing = null;
-                _httpHelper.JWToken = jwtResponse?.Data?.Token;
-            } else {
-                throw new ArgumentException($"Authentication methode {AuthMethod} is not supported");
+                    new KeyValuePair<string, string>("password", password)
+            });
+            
+            switch (JWTPlugin) {
+                case JWTPlugin.JWTAuthByEnriqueChavez:
+                    var (jwtUser, _) = await _httpHelper.PostRequestAsync<JWTUser>(route, formContent, isAuthRequired: false, ignoreDefaultPath: true).ConfigureAwait(false);
+                    _httpHelper.JWToken = jwtUser?.Token;
+                    break;
+                case JWTPlugin.JWTAuthByUsefulTeam:
+                    _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
+                    var (jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, formContent, isAuthRequired: false, ignoreDefaultPath: true).ConfigureAwait(false);
+                    _httpHelper.HttpResponsePreProcessing = null;
+                    _httpHelper.JWToken = jwtResponse?.Data?.Token;
+                    break;
+                default:
+                    throw new WPException("Invalid JWT Plugin");
             }
         }
 
@@ -72,6 +110,7 @@ namespace WordPressPCL.Client {
         /// </summary>
         public void Logout() {
             _httpHelper.JWToken = default;
+            _httpHelper.UserName = default;
             _httpHelper.ApplicationPassword = default;
         }
 
@@ -80,18 +119,23 @@ namespace WordPressPCL.Client {
         /// </summary>
         /// <returns>Result of checking</returns>
         public async Task<bool> IsValidJWTokenAsync() {
+            if (AuthMethod == AuthMethod.Basic) {
+                throw new WPException("Cannot check validity of JWToken with Basic Authentication");
+            }
+
             var route = $"{JwtPath}token/validate";
             try {
-                if (JWTPlugin == JWTPlugin.JWTAuthByEnriqueChavez) {
-                    (JWTUser jwtUser, HttpResponseMessage repsonse) = await _httpHelper.PostRequestAsync<JWTUser>(route, null, isAuthRequired: true, ignoreDefaultPath: true).ConfigureAwait(false);
-                    return repsonse.IsSuccessStatusCode;
-                } else if (JWTPlugin == JWTPlugin.JWTAuthByUsefulTeam) {
-                    _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
-                    (JWTResponse jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, null, isAuthRequired: true, ignoreDefaultPath: true).ConfigureAwait(false);
-                    _httpHelper.HttpResponsePreProcessing = null;
-                    return jwtResponse.Success;
-                } else {
-                    throw new ArgumentException($"Authentication method {AuthMethod} is not supported");
+                switch (JWTPlugin) {
+                    case JWTPlugin.JWTAuthByEnriqueChavez:
+                        var (jwtUser, repsonse) = await _httpHelper.PostRequestAsync<JWTUser>(route, null, isAuthRequired: true, ignoreDefaultPath: true).ConfigureAwait(false);
+                        return repsonse.IsSuccessStatusCode;
+                    case JWTPlugin.JWTAuthByUsefulTeam:
+                        _httpHelper.HttpResponsePreProcessing = RemoveEmptyData;
+                        var (jwtResponse, _) = await _httpHelper.PostRequestAsync<JWTResponse>(route, null, isAuthRequired: true, ignoreDefaultPath: true).ConfigureAwait(false);
+                        _httpHelper.HttpResponsePreProcessing = null;
+                        return jwtResponse.Success;
+                    default:
+                        throw new WPException("Invalid JWT Plugin");
                 }
             } catch (WPException) {
                 return false;
@@ -125,14 +169,6 @@ namespace WordPressPCL.Client {
         /// <returns></returns>
         public string GetToken() {
             return _httpHelper.JWToken;
-        }
-
-        /// <summary>
-        /// Store Application Password in the Client
-        /// </summary>
-        /// <param name="applicationPassword"></param>
-        public void SetApplicationPassword(string applicationPassword) {
-            _httpHelper.ApplicationPassword = applicationPassword;
         }
 
     }

--- a/WordPressPCL/Utility/HttpHelper.cs
+++ b/WordPressPCL/Utility/HttpHelper.cs
@@ -28,17 +28,17 @@ namespace WordPressPCL.Utility
         /// <summary>
         /// The Application Password to be used for authentication
         /// </summary>
-        public string ApplicationPassword { get; set; }
+        internal string ApplicationPassword { get; set; }
 
         /// <summary>
         /// Authentication Method
         /// </summary>
-        public AuthMethod AuthMethod { get; set; }
+        internal AuthMethod AuthMethod { get; set; }
 
         /// <summary>
         /// The username to be used with the Application Password
         /// </summary>
-        public string UserName { get; set; }
+        internal string UserName { get; set; }
 
         /// <summary>
         /// Function called when a HttpRequest response is read

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -46,36 +46,6 @@ namespace WordPressPCL
         }
 
         /// <summary>
-        /// Authentication method
-        /// </summary>
-        public AuthMethod AuthMethod 
-        {
-            get => _httpHelper.AuthMethod;
-            set 
-            { 
-                _httpHelper.AuthMethod = value;
-                Auth.AuthMethod = value;
-            }
-        }
-
-        /// <summary>
-        /// JWTAuth Plugin
-        /// </summary>
-        public JWTPlugin JWTPlugin 
-        {
-            get => Auth.JWTPlugin;
-            set => Auth.JWTPlugin = value;
-        }
-
-        /// <summary>
-        /// The username to be used with the Application Password
-        /// </summary>
-        public string UserName {
-            get => _httpHelper.UserName;
-            set => _httpHelper.UserName = value;
-        }
-
-        /// <summary>
         /// Auth client interaction object
         /// </summary>
         public Auth Auth { get; private set; }
@@ -153,7 +123,9 @@ namespace WordPressPCL
         /// </summary>
         /// <param name="uri">URI for WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/"</param>
         /// <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
-        public WordPressClient(string uri, string defaultPath = DEFAULT_PATH): this(new Uri(uri), defaultPath)
+        public WordPressClient(
+            string uri,
+            string defaultPath = DEFAULT_PATH): this(new Uri(uri), defaultPath)
         {
         }
 
@@ -174,8 +146,7 @@ namespace WordPressPCL
             SetupSubClients(_httpHelper);
         }
 
-        private void SetupSubClients(HttpHelper httpHelper)
-        {
+        private void SetupSubClients(HttpHelper httpHelper) {
             Auth = new Auth(httpHelper);
             Posts = new Posts(httpHelper);
             Comments = new Comments(httpHelper);

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -19,6 +19,11 @@
             JWT Plugin
             </summary>
         </member>
+        <member name="P:WordPressPCL.Client.Auth.Username">
+            <summary>
+            Username for Basic Authentication
+            </summary>
+        </member>
         <member name="F:WordPressPCL.Client.Auth._httpHelper">
             <summary>
             Helper for HTTP requests
@@ -30,12 +35,25 @@
             </summary>
             <param name="httpHelper">reference to HttpHelper class for interaction with HTTP</param>
         </member>
+        <member name="M:WordPressPCL.Client.Auth.UseBearerAuth(WordPressPCL.Models.JWTPlugin)">
+            <summary>
+            Sets up the Auth Client to use Bearer Authentication with specified JWTPlugin
+            </summary>
+            <param name="jwtPlugin">JWT Plugin to use for Bearer Authentication</param>
+        </member>
+        <member name="M:WordPressPCL.Client.Auth.UseBasicAuth(System.String,System.String)">
+            <summary>
+            Sets up the Auth Client to use Basic Authentication with Application Password
+            </summary>
+            <param name="username">Username for Basic Authentication</param>
+            <param name="applicationPassword">Application Password for Basic Authentication</param>
+        </member>
         <member name="M:WordPressPCL.Client.Auth.RequestJWTokenAsync(System.String,System.String)">
             <summary>
             Perform authentication by JWToken
             </summary>
             <param name="username">username</param>
-            <param name="Password">password</param>
+            <param name="password">password</param>
         </member>
         <member name="M:WordPressPCL.Client.Auth.Logout">
             <summary>
@@ -66,12 +84,6 @@
             Gets the JWToken from the client
             </summary>
             <returns></returns>
-        </member>
-        <member name="M:WordPressPCL.Client.Auth.SetApplicationPassword(System.String)">
-            <summary>
-            Store Application Password in the Client
-            </summary>
-            <param name="applicationPassword"></param>
         </member>
         <member name="T:WordPressPCL.Client.Categories">
             <summary>
@@ -4107,21 +4119,6 @@
             <summary>
             Serialization/Deserialization settings for Json.NET library
             https://www.newtonsoft.com/json/help/html/SerializationSettings.htm
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.WordPressClient.AuthMethod">
-            <summary>
-            Authentication method
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.WordPressClient.JWTPlugin">
-            <summary>
-            JWTAuth Plugin
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.WordPressClient.UserName">
-            <summary>
-            The username to be used with the Application Password
             </summary>
         </member>
         <member name="P:WordPressPCL.WordPressClient.Auth">


### PR DESCRIPTION
1. The Auth related properties are removed from the WordpressClient.
2. The Auth sub client has the properties for `AuthMethod`, `JWTPlugin`, `Username` and two new methods `UseBearerAuth` and `UseBasicAuth`. These methods allow to cohesively set the authentication properties depending on the Authentication method (Bearer or Basic) and make sure that the auth settings are passed down to the `HttpHelper`. These two methods also make the library flexible by allowing the client to switch between the authentication methods.
3. The properties `AuthMethod`, `JWTPlugin`, `Username` are get only to display the details. These can be set via `UseBearerAuth` or `UseBasicAuth` only.
4. If the client uses `UseBasicAuth` to set up basic authentication but the invokes either `RequestJWTokenAsync` or `IsValidJWTokenAsync`, then a `WPException` will be thrown. This is done to disallow generating tokens when they are not supposed to be generated.
5. The constructors of `WordpressClient` have not changed. So, the construction of the client remains the same, however since we removed the Auth properties from `WordpressClient`, now it is library user's responsibility to setup auth after the construction of client.

```
//Cannot do anymore
var client = new WordpressClient("some uri") {
    AuthMethod = AuthMethod.Bearer,
    JWTPlugin = JWTPlugin.JWTAuthByEnriqueChavez
}

//Now the api is like
var client = new WordpressClient("some uri");
//this step is necessary to setup auth
//if Bearer Auth
client.Auth.UseBearerAuth(JWTPlugin.JWTAuthByEnriqueChavez);  
//if Basic Auth
client.Auth.UseBasicAuth("some username", "some application password");
```

6. The authentication defaults to Bearer Authentication with JWT Auth by Enrique Chavez being the default plugin. This behaviour is same as previous versions.
7. Visibility modifiers changed in HttpHelper for auth related properties as they should only come via Auth sub client now.