### PR TITLE
Mediaquerybuilder fix

### DIFF
--- a/WordPressPCL.Tests.Selfhosted/Media_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Media_Tests.cs
@@ -131,7 +131,7 @@ namespace WordPressPCL.Tests.Selfhosted
                 Order = Order.ASC,
             };
             var queryresult = await _clientAuth.Media.QueryAsync(queryBuilder);
-            Assert.AreEqual("?page=1&per_page=15&orderby=date&media_type=image&order=asc&context=view", queryBuilder.BuildQuery());
+            Assert.AreEqual("?page=1&per_page=15&orderby=date&order=asc&context=view", queryBuilder.BuildQuery());
             Assert.IsNotNull(queryresult);
             Assert.AreNotSame(queryresult.Count(), 0);
         }

--- a/WordPressPCL/Models/Enums.cs
+++ b/WordPressPCL/Models/Enums.cs
@@ -501,6 +501,12 @@ namespace WordPressPCL.Models
     public enum MediaQueryType
     {
         /// <summary>
+        /// All
+        /// </summary>
+        [EnumMember(Value = "all")]
+        All,
+        
+        /// <summary>
         /// Image
         /// </summary>
         [EnumMember(Value = "image")]

--- a/WordPressPCL/Models/Enums.cs
+++ b/WordPressPCL/Models/Enums.cs
@@ -522,6 +522,12 @@ namespace WordPressPCL.Models
         /// Application
         /// </summary>
         [EnumMember(Value = "application")]
-        Application
+        Application,
+        
+        /// <summary>
+        /// Text
+        /// </summary>
+        [EnumMember(Value = "text")]
+        Text
     }
 }

--- a/WordPressPCL/Utility/ExcludeQueryTextAttribute.cs
+++ b/WordPressPCL/Utility/ExcludeQueryTextAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace WordPressPCL.Utility {
+    /// <summary>
+    /// Attribute to exclude query text in querybuilder
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class ExcludeQueryTextAttribute : Attribute {
+
+        /// <summary>
+        /// Value which determines if query text is excluded
+        /// </summary>
+        public string ExclusionValue { get; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="exclusionValue">value which determines if query text is excluded</param>
+        public ExcludeQueryTextAttribute(string exclusionValue) {
+            ExclusionValue = exclusionValue;
+        }
+    }
+}

--- a/WordPressPCL/Utility/MediaQueryBuilder.cs
+++ b/WordPressPCL/Utility/MediaQueryBuilder.cs
@@ -114,6 +114,7 @@ namespace WordPressPCL.Utility
         /// <summary>
         /// Limit result set to attachments of a particular media type.
         /// </summary>
+        [ExcludeQueryText("all")]
         [QueryText("media_type")]
         public MediaQueryType MediaType { get; set; }
 

--- a/WordPressPCL/Utility/QueryBuilder.cs
+++ b/WordPressPCL/Utility/QueryBuilder.cs
@@ -46,11 +46,14 @@ namespace WordPressPCL.Utility
             foreach (var property in GetType().GetRuntimeProperties())
             {
                 var attribute = property.GetCustomAttribute<QueryTextAttribute>();
+                var exclusionAttribute = property.GetCustomAttribute<ExcludeQueryTextAttribute>();
                 if (attribute != null)
                 {
                     var value = GetPropertyValue(property);
 
                     if (value is null) continue;
+                    if (exclusionAttribute != null && value.ToString().ToLowerInvariant() == exclusionAttribute.ExclusionValue) continue;
+
                     //pass default values
                     if (value is int valueInt && valueInt == default) continue;
                     if (value is string valueString && (string.IsNullOrEmpty(valueString) || valueString == DateTime.MinValue.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture))) continue;

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -1552,6 +1552,11 @@
             Type of Media Query Item
             </summary>
         </member>
+        <member name="F:WordPressPCL.Models.MediaQueryType.All">
+            <summary>
+            All
+            </summary>
+        </member>
         <member name="F:WordPressPCL.Models.MediaQueryType.Image">
             <summary>
             Image
@@ -1570,6 +1575,11 @@
         <member name="F:WordPressPCL.Models.MediaQueryType.Application">
             <summary>
             Application
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.MediaQueryType.Text">
+            <summary>
+            Text
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.Exceptions.WPException">
@@ -3510,6 +3520,22 @@
         </member>
         <member name="M:WordPressPCL.Utility.CustomCapabilitiesJsonConverter.WriteJson(Newtonsoft.Json.JsonWriter,System.Boolean,Newtonsoft.Json.JsonSerializer)">
             <inheritdoc />
+        </member>
+        <member name="T:WordPressPCL.Utility.ExcludeQueryTextAttribute">
+            <summary>
+            Attribute to exclude query text in querybuilder
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.ExcludeQueryTextAttribute.ExclusionValue">
+            <summary>
+            Value which determines if query text is excluded
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Utility.ExcludeQueryTextAttribute.#ctor(System.String)">
+            <summary>
+            Constructor
+            </summary>
+            <param name="exclusionValue">value which determines if query text is excluded</param>
         </member>
         <member name="T:WordPressPCL.Utility.HttpHelper">
             <summary>


### PR DESCRIPTION
Observed: `MediaQueryBuilder` was only returning images on query because the property `MediaType` was taking the default value of `Image` from `MediaQueryType` enum.

Fix:

- Added a `ExcludeQueryTextAttribute` to decorate properties which are to be excluded from the final query parameters.
- If the `ExclusionValue` property of `ExcludeQueryTextAttribute` matches the value of the decorated property, then the decorated property's query text is not included in the final query parameters.
- Added the logic in the `BuildQuery` method which compares the `ExclusionValue` property to the actual value of the decorated property and excludes the property query text if it is a match.

Also added `Text` type in the `MediaQueryType` enum as `Text` is supported by WP Rest Api (as per docs)