### PR TITLE
Manage Wordpress plugins: get all, install, activate, deactivate & delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ var commentbyid = await client.Comments.GetByIdAsync(id);
 var commentsbypost = await client.Comments.GetCommentsForPostAsync(postid, true, false);
 
 // Plugins
-var plugins = await client.Plugins.GetAllAsync();
+var plugins = await client.Plugins.GetAllAsync(useAuth:true);
 var installedplugin = await client.Plugins.InstallAsync("akismet");
 var activateplugin = await client.Plugins.ActivateAsync(installedplugin);
 var deactivateplugin = await client.Plugins.DeactivateAsync(installedplugin);

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ var comments = await client.Comments.GetAllAsync();
 var commentbyid = await client.Comments.GetByIdAsync(id);
 var commentsbypost = await client.Comments.GetCommentsForPostAsync(postid, true, false);
 
+// Plugins
+var plugins = await client.Plugins.GetAllAsync();
+var installedplugin = await client.Plugins.InstallAsync("akismet");
+var activateplugin = await client.Plugins.ActivateAsync(installedplugin);
+var deactivateplugin = await client.Plugins.DeactivateAsync(installedplugin);
+var deleteplugin = await client.Plugins.DeleteAsync(installedplugin);
+
 // Authentication
 var client = new WordPressClient(ApiCredentials.WordPressUri);
 
@@ -104,6 +111,8 @@ var response = client.Posts.DeleteAsync(postId);
 | **Post Types**     | ---     | yes     | ---     | ---     |
 | **Post Statuses**  | ---     | yes     | ---     | ---     |
 | **Settings**       | ---     | yes     | yes     | ---     |
+| **Plugins**        | yes     | yes     | yes     | yes     |
+
 
 ## Additional Features
 

--- a/WordPressPCL.Tests.Selfhosted/Plugins_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Plugins_Tests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using WordPressPCL;
+using WordPressPCL.Client;
+using WordPressPCL.Models;
+using WordPressPCL.Tests.Selfhosted.Utility;
+using WordPressPCL.Utility;
+
+namespace WordPressPCL.Tests.Selfhosted;
+
+[TestClass]
+public class Plugins_Tests
+{
+    private static WordPressClient _clientAuth;
+    private static string PluginId= "wordpress-seo";
+
+    [ClassInitialize]
+    public static async Task Init(TestContext testContext)
+    {
+        _clientAuth = await ClientHelper.GetAuthenticatedWordPressClient(testContext);
+    }
+
+    [TestMethod]
+    public async Task Plugins_Install_Activate_Deactivate_Delete()
+    {
+        var plugin = await _clientAuth.Plugins.InstallAsync(PluginId);
+        Assert.IsNotNull(plugin);
+        Assert.AreEqual(PluginId, plugin.Id);
+
+
+        //Activate plugin
+        var activePlugin = await _clientAuth.Plugins.ActivateAsync(plugin);
+        Assert.AreEqual(activePlugin.Status, ActivationStatus.Active);
+        Assert.AreEqual(activePlugin.Id, plugin.Id);
+
+        //Deactivate plugin
+        var deactivatedPlugin = await _clientAuth.Plugins.DeactivateAsync(plugin);
+        Assert.AreEqual(deactivatedPlugin.Status, ActivationStatus.Inactive);
+        Assert.AreEqual(deactivatedPlugin.Id, plugin.Id);
+
+        //Delete plugin
+        var response = await _clientAuth.Plugins.DeleteAsync(plugin);
+        Assert.IsTrue(response);
+        var plugins = await _clientAuth.Plugins.GetAllAsync(useAuth: true);
+        var c = plugins.Where(x => x.Id == plugin.Id).ToList();
+        Assert.AreEqual(c.Count, 0);
+    }
+
+    [TestMethod]
+    public async Task Plugins_Get()
+    {
+        var plugins = await _clientAuth.Plugins.GetAsync (useAuth: true);
+        Assert.IsNotNull(plugins);
+        Assert.AreNotEqual(plugins.Count(), 0);
+        CollectionAssert.AllItemsAreUnique(plugins.Select(tag => tag.Id).ToList());
+    }
+
+}

--- a/WordPressPCL.Tests.Selfhosted/Plugins_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Plugins_Tests.cs
@@ -36,6 +36,7 @@ public class Plugins_Tests
         Assert.AreEqual(activePlugin.Status, ActivationStatus.Active);
         Assert.AreEqual(activePlugin.Id, plugin.Id);
 
+
         //Deactivate plugin
         var deactivatedPlugin = await _clientAuth.Plugins.DeactivateAsync(plugin);
         Assert.AreEqual(deactivatedPlugin.Status, ActivationStatus.Inactive);
@@ -50,12 +51,38 @@ public class Plugins_Tests
     }
 
     [TestMethod]
+    public async Task Plugins_GetActive()
+    {
+        //Active plugin
+        var plugins = await _clientAuth.Plugins.QueryAsync(new PluginsQueryBuilder { Status = ActivationStatus.Active }, useAuth:true);
+        Assert.IsNotNull(plugins);
+        Assert.AreNotEqual(plugins.Count(), 0);
+
+    }
+    [TestMethod]
+    public async Task Plugins_Search ()
+    {
+        //Active plugin
+        var plugins = await _clientAuth.Plugins.QueryAsync(new PluginsQueryBuilder { Search="jwt" }, useAuth:true);
+        Assert.IsNotNull(plugins);
+        Assert.AreNotEqual(plugins.Count(), 0);
+
+    }
+
+    [TestMethod]
     public async Task Plugins_Get()
     {
         var plugins = await _clientAuth.Plugins.GetAsync (useAuth: true);
         Assert.IsNotNull(plugins);
         Assert.AreNotEqual(plugins.Count(), 0);
         CollectionAssert.AllItemsAreUnique(plugins.Select(tag => tag.Id).ToList());
+    }
+
+    [TestMethod]
+    public async Task Plugins_GetByID()
+    {
+        var plugin = await _clientAuth.Plugins.GetByIDAsync("jwt-auth/jwt-auth", useAuth: true);
+        Assert.IsNotNull(plugin);
     }
 
 }

--- a/WordPressPCL.Tests.Selfhosted/Themes_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/Themes_Tests.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using WordPressPCL;
+using WordPressPCL.Client;
+using WordPressPCL.Models;
+using WordPressPCL.Tests.Selfhosted.Utility;
+using WordPressPCL.Utility;
+
+namespace WordPressPCL.Tests.Selfhosted;
+
+[TestClass]
+public class Themes_Tests
+{
+    private static WordPressClient _clientAuth;
+
+    [ClassInitialize]
+    public static async Task Init(TestContext testContext)
+    {
+        _clientAuth = await ClientHelper.GetAuthenticatedWordPressClient(testContext);
+    }
+
+    [TestMethod]
+    public async Task Themes_GetActive()
+    {
+        var themes = await _clientAuth.Themes.QueryAsync(new ThemesQueryBuilder { Status = ActivationStatus.Active }, useAuth:true);
+        Assert.IsNotNull(themes);
+        Assert.AreNotEqual(themes.Count(), 0);
+
+    }
+    [TestMethod]
+    public async Task Themes_Get()
+    {
+        var themes = await _clientAuth.Themes.GetAsync (useAuth: true);
+        Assert.IsNotNull(themes);
+        Assert.AreNotEqual(themes.Count(), 0);
+        CollectionAssert.AllItemsAreUnique(themes.Select(tag => tag.Stylesheet).ToList());
+    }
+
+    [TestMethod]
+    public async Task Themes_GetByID()
+    {
+        var theme = await _clientAuth.Themes.GetByIDAsync("twentytwentythree", useAuth: true);
+        Assert.IsNotNull(theme);
+    }
+
+}

--- a/WordPressPCL/Client/Plugins.cs
+++ b/WordPressPCL/Client/Plugins.cs
@@ -14,6 +14,8 @@ namespace WordPressPCL.Client
 {
     /// <summary>
     /// Client class for interaction with Plugins endpoint WP REST API
+    /// Date: 26 May 2023
+    /// Creator: Gregory Liénard
     /// </summary>
     public class Plugins : CRUDOperation<Plugin, PluginsQueryBuilder>
     {

--- a/WordPressPCL/Client/Plugins.cs
+++ b/WordPressPCL/Client/Plugins.cs
@@ -110,7 +110,7 @@ namespace WordPressPCL.Client
         {
             // default values
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return HttpHelper.GetRequestAsync<IEnumerable<Plugin>>(_methodPath.SetQueryParam("status", activationStatus.ToString()), embed, true);
+            return HttpHelper.GetRequestAsync<IEnumerable<Plugin>>(_methodPath.SetQueryParam("status", activationStatus.ToString().ToLower()), embed, true);
         }
 
 

--- a/WordPressPCL/Client/Plugins.cs
+++ b/WordPressPCL/Client/Plugins.cs
@@ -1,0 +1,103 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime;
+using System.Text;
+using System.Threading.Tasks;
+using WordPressPCL.Interfaces;
+using WordPressPCL.Models;
+using WordPressPCL.Utility;
+
+namespace WordPressPCL.Client
+{
+    /// <summary>
+    /// Client class for interaction with Plugins endpoint WP REST API
+    /// </summary>
+    public class Plugins : CRUDOperation<Plugin, PluginsQueryBuilder>
+    {
+        #region Init
+
+        private const string _methodPath = "plugins";
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
+        public Plugins(HttpHelper HttpHelper) : base(HttpHelper, _methodPath)
+        {
+        }
+
+        #endregion Init
+
+        #region Custom
+
+        /// <summary>
+        /// Installs a plugin based on the Plugin
+        /// </summary>
+        /// <param name="Plugin"></param>
+        /// <returns></returns>
+        public async Task<Plugin> InstallAsync(Plugin Plugin)
+        {
+
+            using var postBody = new StringContent(JsonConvert.SerializeObject(new { slug = Plugin.Id }), Encoding.UTF8, "application/json");
+            var (plugin, _) = await _httpHelper.PostRequestAsync<Models.Plugin>("plugins", postBody).ConfigureAwait(false);
+            return plugin;
+
+        }
+
+        /// <summary>
+        /// Installs a plugin based on the Id
+        /// </summary>
+        /// <param name="Id"></param>
+        /// <returns></returns>
+        public async Task<Plugin> InstallAsync(string Id)
+        {
+
+            using var postBody = new StringContent(JsonConvert.SerializeObject(new { slug=Id }), Encoding.UTF8, "application/json");
+            var (plugin, _) = await _httpHelper.PostRequestAsync<Models.Plugin>("plugins", postBody).ConfigureAwait(false);
+            return plugin;
+        }
+
+        /// <summary>
+        /// Activates an existing plugin
+        /// </summary>
+        /// <param name="Plugin"></param>
+        /// <returns></returns>
+        public async Task<Plugin> ActivateAsync(Plugin Plugin)
+        {
+            using var postBody = new StringContent(JsonConvert.SerializeObject(new { status = "active" }), Encoding.UTF8, "application/json");
+            var (plugin, _) = await _httpHelper.PostRequestAsync<Models.Plugin>($"plugins/{Plugin.PluginFile}", postBody).ConfigureAwait(false);
+            return plugin;
+        }
+
+        /// <summary>
+        /// Deactivates an existing plugin
+        /// </summary>
+        /// <param name="Plugin"></param>
+        /// <returns></returns>
+        public async Task<Plugin> DeactivateAsync(Plugin Plugin)
+        {
+
+            using var postBody = new StringContent(JsonConvert.SerializeObject(new { status = "inactive" }), Encoding.UTF8, "application/json");
+            var (plugin, _) = await _httpHelper.PostRequestAsync<Models.Plugin>($"plugins/{Plugin.PluginFile}", postBody).ConfigureAwait(false);
+            return plugin;
+        }
+
+
+        /// <summary>
+        /// Deletes an existing plugin
+        /// </summary>
+        /// <param name="Plugin"></param>
+        /// <returns></returns>
+        public Task<bool> DeleteAsync(Plugin Plugin)
+        {
+#pragma warning disable CA1507 // Use nameof to express symbol names
+            return HttpHelper.DeleteRequestAsync($"{_methodPath}/{Plugin.PluginFile}");
+#pragma warning restore CA1507 // Use nameof to express symbol names
+        }
+
+        #endregion Custom
+    }
+}

--- a/WordPressPCL/Client/Plugins.cs
+++ b/WordPressPCL/Client/Plugins.cs
@@ -87,6 +87,32 @@ namespace WordPressPCL.Client
             return plugin;
         }
 
+        /// <summary>
+        /// Get plugins by search term
+        /// </summary>
+        /// <param name="searchTerm">Search term</param>
+        /// <param name="embed">include embed info</param>
+        /// <returns>List of posts</returns>
+        public Task<IEnumerable<Plugin>> GetPluginsBySearchAsync(string searchTerm, bool embed = false)
+        {
+            // default values
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return HttpHelper.GetRequestAsync<IEnumerable<Plugin>>(_methodPath.SetQueryParam("search", searchTerm), embed,true);
+        }
+
+        /// <summary>
+        /// Get plugins by search term
+        /// </summary>
+        /// <param name="activationStatus">active or inactive</param>
+        /// <param name="embed">include embed info</param>
+        /// <returns>List of posts</returns>
+        public Task<IEnumerable<Plugin>> GetPluginsByActivationStatusAsync(ActivationStatus activationStatus, bool embed = false)
+        {
+            // default values
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return HttpHelper.GetRequestAsync<IEnumerable<Plugin>>(_methodPath.SetQueryParam("status", activationStatus.ToString()), embed, true);
+        }
+
 
         /// <summary>
         /// Deletes an existing plugin

--- a/WordPressPCL/Client/Themes.cs
+++ b/WordPressPCL/Client/Themes.cs
@@ -47,7 +47,7 @@ namespace WordPressPCL.Client
         {
             // default values
             // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
-            return HttpHelper.GetRequestAsync<IEnumerable<Theme>>(_methodPath.SetQueryParam("status", activationStatus.ToString()), embed, true);
+            return HttpHelper.GetRequestAsync<IEnumerable<Theme>>(_methodPath.SetQueryParam("status", activationStatus.ToString().ToLower()), embed, true);
         }
 
 

--- a/WordPressPCL/Client/Themes.cs
+++ b/WordPressPCL/Client/Themes.cs
@@ -1,0 +1,57 @@
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime;
+using System.Text;
+using System.Threading.Tasks;
+using WordPressPCL.Interfaces;
+using WordPressPCL.Models;
+using WordPressPCL.Utility;
+
+namespace WordPressPCL.Client
+{
+    /// <summary>
+    /// Client class for interaction with Themes endpoint WP REST API
+    /// Date: 26 May 2023
+    /// Creator: Gregory Liénard
+    /// </summary>
+    public class Themes : CRUDOperation<Theme, ThemesQueryBuilder>
+    {
+        #region Init
+
+        private const string _methodPath = "themes";
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
+        public Themes(HttpHelper HttpHelper) : base(HttpHelper, _methodPath)
+        {
+        }
+
+        #endregion Init
+
+        #region Custom
+
+        
+
+        /// <summary>
+        /// Get themes by search term
+        /// </summary>
+        /// <param name="activationStatus">active or inactive</param>
+        /// <param name="embed">include embed info</param>
+        /// <returns>List of posts</returns>
+        public Task<IEnumerable<Theme>> GetThemesByActivationStatusAsync(ActivationStatus activationStatus, bool embed = false)
+        {
+            // default values
+            // int page = 1, int per_page = 10, int offset = 0, Post.OrderBy orderby = Post.OrderBy.date
+            return HttpHelper.GetRequestAsync<IEnumerable<Theme>>(_methodPath.SetQueryParam("status", activationStatus.ToString()), embed, true);
+        }
+
+
+
+        #endregion Custom
+    }
+}

--- a/WordPressPCL/Models/Enums.cs
+++ b/WordPressPCL/Models/Enums.cs
@@ -67,6 +67,25 @@ namespace WordPressPCL.Models
     }
 
     /// <summary>
+    /// Status of Plugin
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum ActivationStatus
+    {
+        /// <summary>
+        /// Status is active
+        /// </summary>
+        [EnumMember(Value = "active")]
+        Active,
+
+        /// <summary>
+        /// Status is inactive
+        /// </summary>
+        [EnumMember(Value = "inactive")]
+        Inactive,
+    }
+
+    /// <summary>
     /// Status of Comments
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]

--- a/WordPressPCL/Models/Plugin.cs
+++ b/WordPressPCL/Models/Plugin.cs
@@ -1,0 +1,109 @@
+﻿using Newtonsoft.Json;
+
+namespace WordPressPCL.Models
+{
+    /// <summary>
+    /// WordPress main settings
+    /// </summary>
+    public class Plugin
+    {
+        /// <summary>
+        /// The plugin file. unique identifier.
+        /// </summary>
+        [JsonProperty("plugin")]
+        public string PluginFile
+        {
+            get
+            {
+                return _PluginFile;
+            }
+            set
+            {
+                _PluginFile = value;
+                if (value.Contains("/"))
+                    Id = value.Substring(0, value.IndexOf("/"));
+                else
+                    Id = value;
+            }
+        }
+        private string _PluginFile;
+
+        /// <summary>
+        /// First part of the pluginfile: wordpress-seo/wp-seo => wordpress-seo
+        /// Id is needed to install, PluginFile is needed to activate, deactivate, delete
+        /// </summary>
+        public string Id { get ; set; }
+
+        /// <summary>
+        /// The plugin activation status.
+        /// </summary>
+        [JsonProperty("status")]
+        public ActivationStatus Status { get; set; }
+
+        /// <summary>
+        /// The plugin name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The plugin's website address.
+        /// </summary>
+        [JsonProperty("plugin_uri")]
+        public string PluginUri { get; set; }
+
+        /// <summary>
+        /// The plugin author.
+        /// </summary>
+        [JsonProperty("author")]
+        public string Author { get; set; }
+
+        /// <summary>
+        /// Plugin author's website address.
+        /// </summary>
+        [JsonProperty("author_uri")]
+        public string AuthorUri { get; set; }
+
+        /// <summary>
+        /// The plugin description.
+        /// </summary>
+        [JsonProperty("description")]
+        public Description Description { get; set; }
+
+        /// <summary>
+        /// The plugin version number.
+        /// </summary>
+        [JsonProperty("version")]
+        public string Version { get; set; }
+
+        /// <summary>
+        /// Whether the plugin can only be activated network-wide.
+        /// </summary>
+        [JsonProperty("network_only")]
+        public bool NetworkOnly { get; set; }
+
+        /// <summary>
+        /// Minimum required version of WordPress.
+        /// </summary>
+        [JsonProperty("requires_wp")]
+        public string RequiresWordPress { get; set; }
+
+        /// <summary>
+        /// Minimum required version of PHP.
+        /// </summary>
+        [JsonProperty("requires_php")]
+        public string RequiresPHP { get; set; }
+
+        /// <summary>
+        /// The plugin's text domain.
+        /// </summary>
+        [JsonProperty("textdomain")]
+        public string TextDomain { get; set; }
+
+        /// <summary>
+        /// The plugin's links.
+        /// </summary>
+        [JsonProperty("_links")]
+        public Links Links { get; set; }
+    }
+}

--- a/WordPressPCL/Models/Plugin.cs
+++ b/WordPressPCL/Models/Plugin.cs
@@ -3,7 +3,9 @@
 namespace WordPressPCL.Models
 {
     /// <summary>
-    /// WordPress main settings
+    /// WordPress Plugins
+    /// Date: 26 May 2023
+    /// Creator: Gregory Liénard
     /// </summary>
     public class Plugin
     {

--- a/WordPressPCL/Models/Subclasses.cs
+++ b/WordPressPCL/Models/Subclasses.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace WordPressPCL.Models
 {
@@ -18,6 +19,24 @@ namespace WordPressPCL.Models
         /// </summary>
         [JsonProperty("raw")]
         public string Raw { get; set; }
+    }
+
+    /// <summary>
+    /// Adds a "Rendered" and a "Raw" property to all classes derived from this one
+    /// </summary>
+    public abstract class RenderedArrayRawBase
+    {
+        /// <summary>
+        /// Rendered text
+        /// </summary>
+        [JsonProperty("rendered")]
+        public string  Rendered { get; set; }
+
+        /// <summary>
+        /// Raw HTML text
+        /// </summary>
+        [JsonProperty("raw")]
+        public string [] Raw { get; set; }
     }
 
     /// <summary>
@@ -117,6 +136,145 @@ namespace WordPressPCL.Models
     /// </remarks>
     public class Guid : RenderedRawBase
     {
+    }
+
+    /// <summary>
+    /// The title for the object.
+    /// </summary>
+    /// <remarks>Context: view, edit, embed</remarks>
+    public class Tags : RenderedArrayRawBase
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public Tags()
+        {
+        }
+
+        /// <summary>
+        /// Constructor with same Raw and rendered author
+        /// </summary>
+        /// <param name="Tag">Text for author</param>
+        public Tags(string [] Tag) : this(Tag, string.Join(",",Tag))
+        {
+        }
+
+        /// <summary>
+        /// Constructor with Raw and rendered text
+        /// </summary>
+        /// <param name="TagsRaw">Raw HTML text for author</param>
+        /// <param name="TagsRendered">Rendered text for author</param>
+        public Tags(string[] TagsRaw, string TagsRendered)
+        {
+            Raw = TagsRaw;
+            Rendered = TagsRendered;
+        }
+    }
+
+    public class ThemeSupports
+    {
+        [JsonProperty("align-wide")]
+        public bool AlignWide { get; set; }
+
+        [JsonProperty("automatic-feed-links")]
+        public bool AutomaticFeedLinks { get; set; }
+
+        [JsonProperty("block-templates")]
+        public bool BlockTemplates { get; set; }
+
+        [JsonProperty("block-template-parts")]
+        public bool BlockTemplateParts { get; set; }
+
+        [JsonProperty("custom-background")]
+        public bool CustomBackground { get; set; }
+
+        [JsonProperty("custom-header")]
+        public bool CustomHeader { get; set; }
+
+        [JsonProperty("custom-logo")]
+        public bool CustomLogo { get; set; }
+
+        [JsonProperty("customize-selective-refresh-widgets")]
+        public bool CustomizeSelectiveRefreshWidgets { get; set; }
+
+        [JsonProperty("dark-editor-style")]
+        public bool DarkEditorStyle { get; set; }
+
+        [JsonProperty("disable-custom-colors")]
+        public bool DisableCustomColors { get; set; }
+
+        [JsonProperty("disable-custom-font-sizes")]
+        public bool DisableCustomFontSizes { get; set; }
+
+        [JsonProperty("disable-custom-gradients")]
+        public bool DisableCustomGradients { get; set; }
+
+        [JsonProperty("disable-layout-styles")]
+        public bool DisableLayoutStyles { get; set; }
+
+        [JsonProperty("editor-color-palette")]
+        public bool EditorColorPalette { get; set; }
+
+        [JsonProperty("editor-font-sizes")]
+        public bool EditorFontSizes { get; set; }
+
+        [JsonProperty("editor-gradient-presets")]
+        public bool EditorGradientPresets { get; set; }
+
+        [JsonProperty("editor-styles")]
+        public bool EditorStyles { get; set; }
+
+        [JsonProperty("html5")]
+        public List<string> Html5 { get; set; }
+
+        [JsonProperty("formats")]
+        public List<string> Formats { get; set; }
+
+        [JsonProperty("post-thumbnails")]
+        public bool PostThumbnails { get; set; }
+
+        [JsonProperty("responsive-embeds")]
+        public bool ResponsiveEmbeds { get; set; }
+
+        [JsonProperty("title-tag")]
+        public bool TitleTag { get; set; }
+
+        [JsonProperty("wp-block-styles")]
+        public bool WpBlockStyles { get; set; }
+    }
+
+
+    /// <summary>
+    /// The tags for the object.
+    /// </summary>
+    /// <remarks>Context: view, edit, embed</remarks>
+    public class Rendered : RenderedRawBase
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public Rendered()
+        {
+        }
+
+        /// <summary>
+        /// Constructor with same Raw and rendered author
+        /// </summary>
+        /// <param name="Author">Text for author</param>
+        public Rendered(string Author) : this(Author, Author)
+        {
+        }
+
+        /// <summary>
+        /// Constructor with Raw and rendered text
+        /// </summary>
+        /// <param name="AuthorRaw">Raw HTML text for author</param>
+        /// <param name="AuthorRendered">Rendered text for author</param>
+        public Rendered(string AuthorRaw, string AuthorRendered)
+        {
+            Raw = AuthorRaw;
+            Rendered = AuthorRendered;
+        }
     }
 
     /// <summary>

--- a/WordPressPCL/Models/Theme.cs
+++ b/WordPressPCL/Models/Theme.cs
@@ -78,11 +78,6 @@ namespace WordPressPCL.Models
         [JsonProperty("textdomain")]
         public string Textdomain { get; set; }
 
-        /// <summary>
-        /// Features supported by this theme.
-        /// </summary>
-        [JsonProperty("theme_supports")]
-        public ThemeSupports ThemeSupports { get; set; }
 
         /// <summary>
         /// The URI of the theme's webpage.

--- a/WordPressPCL/Models/Theme.cs
+++ b/WordPressPCL/Models/Theme.cs
@@ -1,0 +1,106 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WordPressPCL.Models
+{
+    /// <summary>
+    /// WordPress Themes
+    /// Date: 8 June 2023
+    /// Creator: Gregory Liénard
+    /// </summary>
+    public class Theme
+    {
+        /// <summary>
+        /// The theme's stylesheet. This uniquely identifies the theme.
+        /// </summary>
+        [JsonProperty("stylesheet")]
+        public string Stylesheet { get; set; }
+
+        /// <summary>
+        /// The theme's template. If this is a child theme, this refers to the parent theme.
+        /// </summary>
+        [JsonProperty("template")]
+        public string Template { get; set; }
+
+        /// <summary>
+        /// The theme author.
+        /// </summary>
+        [JsonProperty("author")]
+        public Rendered Author { get; set; }
+
+        /// <summary>
+        /// The website of the theme author.
+        /// </summary>
+        [JsonProperty("author_uri")]
+        public Rendered AuthorUri { get; set; }
+
+        /// <summary>
+        /// A description of the theme.
+        /// </summary>
+        [JsonProperty("description")]
+        public Description Description { get; set; }
+
+        /// <summary>
+        /// The name of the theme.
+        /// </summary>
+        [JsonProperty("name")]
+        public Rendered Name { get; set; }
+
+        /// <summary>
+        /// The minimum PHP version required for the theme to work.
+        /// </summary>
+        [JsonProperty("requires_php")]
+        public string RequiresPhp { get; set; }
+
+        /// <summary>
+        /// The minimum WordPress version required for the theme to work.
+        /// </summary>
+        [JsonProperty("requires_wp")]
+        public string RequiresWp { get; set; }
+
+        /// <summary>
+        /// The theme's screenshot URL.
+        /// </summary>
+        [JsonProperty("screenshot")]
+        public Uri Screenshot { get; set; }
+
+        /// <summary>
+        /// Tags indicating styles and features of the theme.
+        /// </summary>
+        [JsonProperty("tags")]
+        public Tags Tags { get; set; }
+
+        /// <summary>
+        /// The theme's text domain.
+        /// </summary>
+        [JsonProperty("textdomain")]
+        public string Textdomain { get; set; }
+
+        /// <summary>
+        /// Features supported by this theme.
+        /// </summary>
+        [JsonProperty("theme_supports")]
+        public ThemeSupports ThemeSupports { get; set; }
+
+        /// <summary>
+        /// The URI of the theme's webpage.
+        /// </summary>
+        [JsonProperty("theme_uri")]
+        public Rendered ThemeUri { get; set; }
+
+        /// <summary>
+        /// The theme's current version.
+        /// </summary>
+        [JsonProperty("version")]
+        public Version Version { get; set; }
+
+        /// <summary>
+        /// A named status for the theme.
+        /// </summary>
+        [JsonProperty("status")]
+        public ActivationStatus Status { get; set; }
+    }
+
+}

--- a/WordPressPCL/Utility/PluginsQueryBuilder.cs
+++ b/WordPressPCL/Utility/PluginsQueryBuilder.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using WordPressPCL.Models;
+
+namespace WordPressPCL.Utility
+{
+    /// <summary>
+    /// Plugins Query Builder class to construct queries with valid parameters
+    /// </summary>
+    public class PluginsQueryBuilder : QueryBuilder
+    {
+        /// <summary>
+        /// Current page of the collection.
+        /// </summary>
+        /// <remarks>Default: 1</remarks>
+        [QueryText("page")]
+        public int Page { get; set; }
+
+        /// <summary>
+        /// Maximum number of items to be returned in result set (1-100).
+        /// </summary>
+        /// <remarks>Default: 10</remarks>
+        [QueryText("per_page")]
+        public int PerPage { get; set; }
+
+        /// <summary>
+        /// Limit results to those matching a string.
+        /// </summary>
+        [QueryText("search")]
+        public string Search { get; set; }
+
+        /// <summary>
+        /// Ensure result set excludes specific IDs.
+        /// </summary>
+        [QueryText("exclude")]
+        public List<int> Exclude { get; set; }
+
+        /// <summary>
+        /// Limit result set to specific IDs.
+        /// </summary>
+        [QueryText("include")]
+        public List<int> Include { get; set; }
+
+        /// <summary>
+        /// Offset the result set by a specific number of items.
+        /// </summary>
+        [QueryText("offset")]
+        public int Offset { get; set; }
+
+
+        /// <summary>
+        /// Limit result set to users with a specific slug.
+        /// </summary>
+        [QueryText("slug")]
+        public List<string> Slugs { get; set; }
+
+    }
+}

--- a/WordPressPCL/Utility/ThemesQueryBuilder.cs
+++ b/WordPressPCL/Utility/ThemesQueryBuilder.cs
@@ -4,16 +4,10 @@ using WordPressPCL.Models;
 namespace WordPressPCL.Utility
 {
     /// <summary>
-    /// Plugins Query Builder class to construct queries with valid parameters
+    /// Themes Query Builder class to construct queries with valid parameters
     /// </summary>
-    public class PluginsQueryBuilder : QueryBuilder
+    public class ThemesQueryBuilder : QueryBuilder
     {
-        /// <summary>
-        /// Limit results to those matching a string.
-        /// </summary>
-        [QueryText("search")]
-        public string Search { get; set; }
-
         /// <summary>
         /// Limit results to specific status
         /// </summary>

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -106,6 +106,11 @@ namespace WordPressPCL
         public Settings Settings { get; private set; }
 
         /// <summary>
+        /// Plugins client interaction object
+        /// </summary>
+        public Plugins Plugins { get; private set; }
+
+        /// <summary>
         /// The WordPressClient holds all connection infos and provides methods to call WordPress APIs.
         /// </summary>
         /// <param name="uri">URI for WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/"</param>
@@ -159,6 +164,7 @@ namespace WordPressPCL
             PostStatuses = new PostStatuses(httpHelper);
             CustomRequest = new CustomRequest(httpHelper);
             Settings = new Settings(httpHelper);
+            Plugins = new Plugins(httpHelper);
         }
 
     }

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -111,6 +111,11 @@ namespace WordPressPCL
         public Plugins Plugins { get; private set; }
 
         /// <summary>
+        /// Plugins client interaction object
+        /// </summary>
+        public Themes Themes { get; private set; }
+
+        /// <summary>
         /// The WordPressClient holds all connection infos and provides methods to call WordPress APIs.
         /// </summary>
         /// <param name="uri">URI for WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/"</param>
@@ -165,6 +170,7 @@ namespace WordPressPCL
             CustomRequest = new CustomRequest(httpHelper);
             Settings = new Settings(httpHelper);
             Plugins = new Plugins(httpHelper);
+            Themes = new Themes(httpHelper);
         }
 
     }

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -386,6 +386,8 @@
         <member name="T:WordPressPCL.Client.Plugins">
             <summary>
             Client class for interaction with Plugins endpoint WP REST API
+            Date: 26 May 2023
+            Creator: Gregory Liénard
             </summary>
         </member>
         <member name="M:WordPressPCL.Client.Plugins.#ctor(WordPressPCL.Utility.HttpHelper)">
@@ -421,6 +423,22 @@
             </summary>
             <param name="Plugin"></param>
             <returns></returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.GetPluginsBySearchAsync(System.String,System.Boolean)">
+            <summary>
+            Get plugins by search term
+            </summary>
+            <param name="searchTerm">Search term</param>
+            <param name="embed">include embed info</param>
+            <returns>List of posts</returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.GetPluginsByActivationStatusAsync(WordPressPCL.Models.ActivationStatus,System.Boolean)">
+            <summary>
+            Get plugins by search term
+            </summary>
+            <param name="activationStatus">active or inactive</param>
+            <param name="embed">include embed info</param>
+            <returns>List of posts</returns>
         </member>
         <member name="M:WordPressPCL.Client.Plugins.DeleteAsync(WordPressPCL.Models.Plugin)">
             <summary>
@@ -699,6 +717,27 @@
             <param name="queryBuilder">Query builder with specific parameters</param>
             <param name="useAuth">Send request with authentication header</param>
             <returns>List of filtered result</returns>
+        </member>
+        <member name="T:WordPressPCL.Client.Themes">
+            <summary>
+            Client class for interaction with Themes endpoint WP REST API
+            Date: 26 May 2023
+            Creator: Gregory Liénard
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Client.Themes.#ctor(WordPressPCL.Utility.HttpHelper)">
+            <summary>
+            Constructor
+            </summary>
+            <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
+        </member>
+        <member name="M:WordPressPCL.Client.Themes.GetThemesByActivationStatusAsync(WordPressPCL.Models.ActivationStatus,System.Boolean)">
+            <summary>
+            Get themes by search term
+            </summary>
+            <param name="activationStatus">active or inactive</param>
+            <param name="embed">include embed info</param>
+            <returns>List of posts</returns>
         </member>
         <member name="T:WordPressPCL.Client.Users">
             <summary>
@@ -2367,7 +2406,9 @@
         </member>
         <member name="T:WordPressPCL.Models.Plugin">
             <summary>
-            WordPress main settings
+            WordPress Plugins
+            Date: 26 May 2023
+            Creator: Gregory Liénard
             </summary>
         </member>
         <member name="P:WordPressPCL.Models.Plugin.PluginFile">
@@ -2957,6 +2998,21 @@
             Raw HTML text
             </summary>
         </member>
+        <member name="T:WordPressPCL.Models.RenderedArrayRawBase">
+            <summary>
+            Adds a "Rendered" and a "Raw" property to all classes derived from this one
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.RenderedArrayRawBase.Rendered">
+            <summary>
+            Rendered text
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.RenderedArrayRawBase.Raw">
+            <summary>
+            Raw HTML text
+            </summary>
+        </member>
         <member name="T:WordPressPCL.Models.HrefBase">
             <summary>
             Adds an Href property to all classes derived from this one
@@ -3031,6 +3087,54 @@
             Read only
             Context: view, edit
             </remarks>
+        </member>
+        <member name="T:WordPressPCL.Models.Tags">
+            <summary>
+            The title for the object.
+            </summary>
+            <remarks>Context: view, edit, embed</remarks>
+        </member>
+        <member name="M:WordPressPCL.Models.Tags.#ctor">
+            <summary>
+            Constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Tags.#ctor(System.String[])">
+            <summary>
+            Constructor with same Raw and rendered author
+            </summary>
+            <param name="Tag">Text for author</param>
+        </member>
+        <member name="M:WordPressPCL.Models.Tags.#ctor(System.String[],System.String)">
+            <summary>
+            Constructor with Raw and rendered text
+            </summary>
+            <param name="TagsRaw">Raw HTML text for author</param>
+            <param name="TagsRendered">Rendered text for author</param>
+        </member>
+        <member name="T:WordPressPCL.Models.Rendered">
+            <summary>
+            The tags for the object.
+            </summary>
+            <remarks>Context: view, edit, embed</remarks>
+        </member>
+        <member name="M:WordPressPCL.Models.Rendered.#ctor">
+            <summary>
+            Constructor
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Models.Rendered.#ctor(System.String)">
+            <summary>
+            Constructor with same Raw and rendered author
+            </summary>
+            <param name="Author">Text for author</param>
+        </member>
+        <member name="M:WordPressPCL.Models.Rendered.#ctor(System.String,System.String)">
+            <summary>
+            Constructor with Raw and rendered text
+            </summary>
+            <param name="AuthorRaw">Raw HTML text for author</param>
+            <param name="AuthorRendered">Rendered text for author</param>
         </member>
         <member name="T:WordPressPCL.Models.Title">
             <summary>
@@ -3358,6 +3462,88 @@
         <member name="M:WordPressPCL.Models.Term.#ctor">
             <summary>
             parameterless constructor
+            </summary>
+        </member>
+        <member name="T:WordPressPCL.Models.Theme">
+            <summary>
+            WordPress Themes
+            Date: 8 June 2023
+            Creator: Gregory Liénard
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Stylesheet">
+            <summary>
+            The theme's stylesheet. This uniquely identifies the theme.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Template">
+            <summary>
+            The theme's template. If this is a child theme, this refers to the parent theme.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Author">
+            <summary>
+            The theme author.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.AuthorUri">
+            <summary>
+            The website of the theme author.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Description">
+            <summary>
+            A description of the theme.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Name">
+            <summary>
+            The name of the theme.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.RequiresPhp">
+            <summary>
+            The minimum PHP version required for the theme to work.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.RequiresWp">
+            <summary>
+            The minimum WordPress version required for the theme to work.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Screenshot">
+            <summary>
+            The theme's screenshot URL.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Tags">
+            <summary>
+            Tags indicating styles and features of the theme.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Textdomain">
+            <summary>
+            The theme's text domain.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.ThemeSupports">
+            <summary>
+            Features supported by this theme.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.ThemeUri">
+            <summary>
+            The URI of the theme's webpage.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Version">
+            <summary>
+            The theme's current version.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Theme.Status">
+            <summary>
+            A named status for the theme.
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.User">
@@ -3969,41 +4155,14 @@
             Plugins Query Builder class to construct queries with valid parameters
             </summary>
         </member>
-        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Page">
-            <summary>
-            Current page of the collection.
-            </summary>
-            <remarks>Default: 1</remarks>
-        </member>
-        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.PerPage">
-            <summary>
-            Maximum number of items to be returned in result set (1-100).
-            </summary>
-            <remarks>Default: 10</remarks>
-        </member>
         <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Search">
             <summary>
             Limit results to those matching a string.
             </summary>
         </member>
-        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Exclude">
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Status">
             <summary>
-            Ensure result set excludes specific IDs.
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Include">
-            <summary>
-            Limit result set to specific IDs.
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Offset">
-            <summary>
-            Offset the result set by a specific number of items.
-            </summary>
-        </member>
-        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Slugs">
-            <summary>
-            Limit result set to users with a specific slug.
+            Limit results to specific status
             </summary>
         </member>
         <member name="T:WordPressPCL.Utility.PostsQueryBuilder">
@@ -4227,6 +4386,16 @@
             Limit results to taxonomies associated with a specific post type.
             </summary>
         </member>
+        <member name="T:WordPressPCL.Utility.ThemesQueryBuilder">
+            <summary>
+            Themes Query Builder class to construct queries with valid parameters
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.ThemesQueryBuilder.Status">
+            <summary>
+            Limit results to specific status
+            </summary>
+        </member>
         <member name="T:WordPressPCL.Utility.ThreadedCommentsHelper">
             <summary>
             Helper class to create threaded comment views
@@ -4416,6 +4585,11 @@
             </summary>
         </member>
         <member name="P:WordPressPCL.WordPressClient.Plugins">
+            <summary>
+            Plugins client interaction object
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.WordPressClient.Themes">
             <summary>
             Plugins client interaction object
             </summary>

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -3526,11 +3526,6 @@
             The theme's text domain.
             </summary>
         </member>
-        <member name="P:WordPressPCL.Models.Theme.ThemeSupports">
-            <summary>
-            Features supported by this theme.
-            </summary>
-        </member>
         <member name="P:WordPressPCL.Models.Theme.ThemeUri">
             <summary>
             The URI of the theme's webpage.

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -383,6 +383,52 @@
             <param name="force">force deletion</param>
             <returns>Result of operation</returns>
         </member>
+        <member name="T:WordPressPCL.Client.Plugins">
+            <summary>
+            Client class for interaction with Plugins endpoint WP REST API
+            </summary>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.#ctor(WordPressPCL.Utility.HttpHelper)">
+            <summary>
+            Constructor
+            </summary>
+            <param name="HttpHelper">reference to HttpHelper class for interaction with HTTP</param>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.InstallAsync(WordPressPCL.Models.Plugin)">
+            <summary>
+            Installs a plugin based on the Plugin
+            </summary>
+            <param name="Plugin"></param>
+            <returns></returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.InstallAsync(System.String)">
+            <summary>
+            Installs a plugin based on the Id
+            </summary>
+            <param name="Id"></param>
+            <returns></returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.ActivateAsync(WordPressPCL.Models.Plugin)">
+            <summary>
+            Activates an existing plugin
+            </summary>
+            <param name="Plugin"></param>
+            <returns></returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.DeactivateAsync(WordPressPCL.Models.Plugin)">
+            <summary>
+            Deactivates an existing plugin
+            </summary>
+            <param name="Plugin"></param>
+            <returns></returns>
+        </member>
+        <member name="M:WordPressPCL.Client.Plugins.DeleteAsync(WordPressPCL.Models.Plugin)">
+            <summary>
+            Deletes an existing plugin
+            </summary>
+            <param name="Plugin"></param>
+            <returns></returns>
+        </member>
         <member name="T:WordPressPCL.Client.PostRevisions">
             <summary>
             Client class for interaction with Post revisions endpoint WP REST API
@@ -1219,6 +1265,21 @@
         <member name="F:WordPressPCL.Models.OpenStatus.Closed">
             <summary>
             Status is closed
+            </summary>
+        </member>
+        <member name="T:WordPressPCL.Models.ActivationStatus">
+            <summary>
+            Status of Plugin
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.ActivationStatus.Active">
+            <summary>
+            Status is active
+            </summary>
+        </member>
+        <member name="F:WordPressPCL.Models.ActivationStatus.Inactive">
+            <summary>
+            Status is inactive
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.CommentStatus">
@@ -2302,6 +2363,82 @@
         <member name="M:WordPressPCL.Models.Page.#ctor">
             <summary>
             Parameterless constructor
+            </summary>
+        </member>
+        <member name="T:WordPressPCL.Models.Plugin">
+            <summary>
+            WordPress main settings
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.PluginFile">
+            <summary>
+            The plugin file. unique identifier.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Id">
+            <summary>
+            First part of the pluginfile: wordpress-seo/wp-seo => wordpress-seo
+            Id is needed to install, PluginFile is needed to activate, deactivate, delete
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Status">
+            <summary>
+            The plugin activation status.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Name">
+            <summary>
+            The plugin name.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.PluginUri">
+            <summary>
+            The plugin's website address.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Author">
+            <summary>
+            The plugin author.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.AuthorUri">
+            <summary>
+            Plugin author's website address.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Description">
+            <summary>
+            The plugin description.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Version">
+            <summary>
+            The plugin version number.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.NetworkOnly">
+            <summary>
+            Whether the plugin can only be activated network-wide.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.RequiresWordPress">
+            <summary>
+            Minimum required version of WordPress.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.RequiresPHP">
+            <summary>
+            Minimum required version of PHP.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.TextDomain">
+            <summary>
+            The plugin's text domain.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Models.Plugin.Links">
+            <summary>
+            The plugin's links.
             </summary>
         </member>
         <member name="T:WordPressPCL.Models.Post">
@@ -3827,6 +3964,48 @@
             Use WP Query arguments to modify the response; private query vars require appropriate authorization.
             </summary>
         </member>
+        <member name="T:WordPressPCL.Utility.PluginsQueryBuilder">
+            <summary>
+            Plugins Query Builder class to construct queries with valid parameters
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Page">
+            <summary>
+            Current page of the collection.
+            </summary>
+            <remarks>Default: 1</remarks>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.PerPage">
+            <summary>
+            Maximum number of items to be returned in result set (1-100).
+            </summary>
+            <remarks>Default: 10</remarks>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Search">
+            <summary>
+            Limit results to those matching a string.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Exclude">
+            <summary>
+            Ensure result set excludes specific IDs.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Include">
+            <summary>
+            Limit result set to specific IDs.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Offset">
+            <summary>
+            Offset the result set by a specific number of items.
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.Utility.PluginsQueryBuilder.Slugs">
+            <summary>
+            Limit result set to users with a specific slug.
+            </summary>
+        </member>
         <member name="T:WordPressPCL.Utility.PostsQueryBuilder">
             <summary>
             Post Query Builder class to construct queries with valid parameters
@@ -4234,6 +4413,11 @@
         <member name="P:WordPressPCL.WordPressClient.Settings">
             <summary>
             Settings client interaction object
+            </summary>
+        </member>
+        <member name="P:WordPressPCL.WordPressClient.Plugins">
+            <summary>
+            Plugins client interaction object
             </summary>
         </member>
         <member name="M:WordPressPCL.WordPressClient.#ctor(System.Uri,System.String)">


### PR DESCRIPTION
Manage Wordpress plugins: get all, install, activate, deactivate & delete

var plugins = await client.Plugins.GetAllAsync(useAuth:true);
var installedplugin = await client.Plugins.InstallAsync("akismet");
var activateplugin = await client.Plugins.ActivateAsync(installedplugin);
var deactivateplugin = await client.Plugins.DeactivateAsync(installedplugin);
var deleteplugin = await client.Plugins.DeleteAsync(installedplugin);