### PR TITLE
Support for HttpClient without BaseAddress set

### DIFF
--- a/WordPressPCL.Tests.Selfhosted/HttpClient_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/HttpClient_Tests.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using WordPressPCL.Tests.Selfhosted.Utility;
 
@@ -12,25 +10,39 @@ namespace WordPressPCL.Tests.Selfhosted;
 [TestClass]
 public class HttpClient_Tests
 {
-    [TestMethod]
-    public async Task CustomHttpClient()
+	[TestMethod]
+    public async Task CustomHttpClient_WithBaseAddress()
     {
         // Initialize
         var httpClient = new HttpClient
         {
             BaseAddress = new Uri(ApiCredentials.WordPressUri)
         };
-        httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:33.0) Gecko/20100101 Firefox/33.0");
-        httpClient.DefaultRequestHeaders.Add("Referer", "https://github.com/wp-net/WordPressPCL");
 
-        var client = new WordPressClient(httpClient);
-        var posts = await client.Posts.GetAllAsync();
-        var post = await client.Posts.GetByIDAsync(posts.First().Id);
-        Assert.IsTrue(posts.First().Id == post.Id);
-        Assert.IsTrue(!string.IsNullOrEmpty(posts.First().Content.Rendered));
-
-        await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
-        var validToken = await client.Auth.IsValidJWTokenAsync();
-        Assert.IsTrue(validToken);
+        await CustomHttpClientBase(httpClient, new WordPressClient(httpClient));
     }
+
+    [TestMethod]
+    public async Task CustomHttpClient_WithoutBaseAddress()
+    {
+	    // Initialize
+	    var httpClient = new HttpClient();
+		var wordPressClient = new WordPressClient(httpClient, uri: new Uri(ApiCredentials.WordPressUri));
+        await CustomHttpClientBase(httpClient, wordPressClient);
+	}
+
+    private async Task CustomHttpClientBase(HttpClient httpClient, WordPressClient client)
+    {
+	    httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:33.0) Gecko/20100101 Firefox/33.0");
+	    httpClient.DefaultRequestHeaders.Add("Referer", "https://github.com/wp-net/WordPressPCL");
+
+	    var posts = await client.Posts.GetAllAsync();
+	    var post = await client.Posts.GetByIDAsync(posts.First().Id);
+	    Assert.IsTrue(posts.First().Id == post.Id);
+	    Assert.IsTrue(!string.IsNullOrEmpty(posts.First().Content.Rendered));
+
+	    await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
+	    var validToken = await client.Auth.IsValidJWTokenAsync();
+	    Assert.IsTrue(validToken);
+	}
 }

--- a/WordPressPCL.Tests.Selfhosted/HttpClient_Tests.cs
+++ b/WordPressPCL.Tests.Selfhosted/HttpClient_Tests.cs
@@ -10,7 +10,7 @@ namespace WordPressPCL.Tests.Selfhosted;
 [TestClass]
 public class HttpClient_Tests
 {
-	[TestMethod]
+    [TestMethod]
     public async Task CustomHttpClient_WithBaseAddress()
     {
         // Initialize
@@ -25,24 +25,24 @@ public class HttpClient_Tests
     [TestMethod]
     public async Task CustomHttpClient_WithoutBaseAddress()
     {
-	    // Initialize
-	    var httpClient = new HttpClient();
-		var wordPressClient = new WordPressClient(httpClient, uri: new Uri(ApiCredentials.WordPressUri));
+        // Initialize
+        var httpClient = new HttpClient();
+        var wordPressClient = new WordPressClient(httpClient, uri: new Uri(ApiCredentials.WordPressUri));
         await CustomHttpClientBase(httpClient, wordPressClient);
-	}
+    }
 
     private async Task CustomHttpClientBase(HttpClient httpClient, WordPressClient client)
     {
-	    httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:33.0) Gecko/20100101 Firefox/33.0");
-	    httpClient.DefaultRequestHeaders.Add("Referer", "https://github.com/wp-net/WordPressPCL");
+        httpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 6.2; WOW64; rv:33.0) Gecko/20100101 Firefox/33.0");
+        httpClient.DefaultRequestHeaders.Add("Referer", "https://github.com/wp-net/WordPressPCL");
 
-	    var posts = await client.Posts.GetAllAsync();
-	    var post = await client.Posts.GetByIDAsync(posts.First().Id);
-	    Assert.IsTrue(posts.First().Id == post.Id);
-	    Assert.IsTrue(!string.IsNullOrEmpty(posts.First().Content.Rendered));
+        var posts = await client.Posts.GetAllAsync();
+        var post = await client.Posts.GetByIDAsync(posts.First().Id);
+        Assert.IsTrue(posts.First().Id == post.Id);
+        Assert.IsTrue(!string.IsNullOrEmpty(posts.First().Content.Rendered));
 
-	    await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
-	    var validToken = await client.Auth.IsValidJWTokenAsync();
-	    Assert.IsTrue(validToken);
-	}
+        await client.Auth.RequestJWTokenAsync(ApiCredentials.Username, ApiCredentials.Password);
+        var validToken = await client.Auth.IsValidJWTokenAsync();
+        Assert.IsTrue(validToken);
+    }
 }

--- a/WordPressPCL/Utility/HttpHelper.cs
+++ b/WordPressPCL/Utility/HttpHelper.cs
@@ -77,14 +77,14 @@ namespace WordPressPCL.Utility
             };
         }
 
-		/// <summary>
-		/// Constructor
-		/// <paramref name="httpClient"/>
-		/// </summary>
-		/// <param name="httpClient">Http client which would be used for sending requests to the WordPress API endpoint.</param>
-		/// <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
-		/// <param name="wordpressURI">(optional) Base WP REST API endpoint EX. http://demo.com/wp-json/. Use this if the BaseAddress of the httpClient is not set.</param>
-		public HttpHelper(HttpClient httpClient, string defaultPath, Uri wordpressURI = null)
+        /// <summary>
+        /// Constructor
+        /// <paramref name="httpClient"/>
+        /// </summary>
+        /// <param name="httpClient">Http client which would be used for sending requests to the WordPress API endpoint.</param>
+        /// <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
+        /// <param name="wordpressURI">(optional) Base WP REST API endpoint EX. http://demo.com/wp-json/. Use this if the BaseAddress of the httpClient is not set.</param>
+        public HttpHelper(HttpClient httpClient, string defaultPath, Uri wordpressURI = null)
         {
             _httpClient = httpClient;
             _defaultPath = defaultPath;
@@ -98,8 +98,8 @@ namespace WordPressPCL.Utility
 
         internal async Task<TClass> GetRequestAsync<TClass>(string route, bool embed, bool isAuthRequired = false, bool ignoreDefaultPath = false)
             where TClass : class
-        {
-	        route = BuildRoute(ignoreDefaultPath, route);
+        { 
+            route = BuildRoute(ignoreDefaultPath, route);
             string embedParam = "";
             if (embed)
             {
@@ -132,8 +132,8 @@ namespace WordPressPCL.Utility
 
         internal async Task<(TClass, HttpResponseMessage)> PostRequestAsync<TClass>(string route, HttpContent postBody, bool isAuthRequired = true, bool ignoreDefaultPath = false)
             where TClass : class
-        {
-	        route = BuildRoute(ignoreDefaultPath, route);
+        { 
+            route = BuildRoute(ignoreDefaultPath, route);
             HttpResponseMessage response;
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, route))
             {
@@ -158,7 +158,7 @@ namespace WordPressPCL.Utility
 
         internal async Task<bool> DeleteRequestAsync(string route, bool isAuthRequired = true, bool ignoreDefaultPath = false)
         {
-	        route = BuildRoute(ignoreDefaultPath, route);
+            route = BuildRoute(ignoreDefaultPath, route);
             HttpResponseMessage response;
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Delete, route))
             {
@@ -180,7 +180,7 @@ namespace WordPressPCL.Utility
 
         internal async Task<HttpResponseHeaders> HeadRequestAsync(string route, bool isAuthRequired = false, bool ignoreDefaultPath = false)
         {
-	        route = BuildRoute(ignoreDefaultPath, route);
+            route = BuildRoute(ignoreDefaultPath, route);
             HttpResponseMessage response;
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Head, route))
             {
@@ -219,8 +219,8 @@ namespace WordPressPCL.Utility
 
         private string BuildRoute(bool ignoreDefaultPath, string route)
         {
-	        if (string.IsNullOrEmpty(route))
-		        return route;
+            if (string.IsNullOrEmpty(route))
+                return route;
 
 	        var processedRoute = ignoreDefaultPath ? route : $"{_defaultPath}{route}";
 

--- a/WordPressPCL/WordPressClient.cs
+++ b/WordPressPCL/WordPressClient.cs
@@ -139,19 +139,20 @@ namespace WordPressPCL
         }
 
 
-        /// <summary>
-        /// The WordPressClient holds all connection infos and provides methods to call WordPress APIs.
-        /// </summary>
-        /// <param name="httpClient">HttpClient with BaseAddress set which will be used for sending requests to the WordPress API endpoint.</param>
-        /// <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
-        public WordPressClient(HttpClient httpClient, string defaultPath = DEFAULT_PATH)
+		/// <summary>
+		/// The WordPressClient holds all connection infos and provides methods to call WordPress APIs.
+		/// </summary>
+		/// <param name="httpClient">HttpClient with BaseAddress set which will be used for sending requests to the WordPress API endpoint.</param>
+		/// <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
+		/// <param name="uri">URI for WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/".  Use this if the BaseAddress of the httpClient is not set.</param>
+		public WordPressClient(HttpClient httpClient, string defaultPath = DEFAULT_PATH, Uri uri = null)
         {
             if (httpClient == null)
             {
                 throw new ArgumentNullException(nameof(httpClient));
             }
-            WordPressUri = httpClient.BaseAddress;
-            _httpHelper = new HttpHelper(httpClient, defaultPath);
+            WordPressUri = uri ?? httpClient.BaseAddress;
+            _httpHelper = new HttpHelper(httpClient, defaultPath, uri);
             SetupSubClients(_httpHelper);
         }
 

--- a/WordPressPCL/WordPressPCL.xml
+++ b/WordPressPCL/WordPressPCL.xml
@@ -3929,13 +3929,14 @@
             <param name="wordpressURI">base WP REST API endpoint EX. http://demo.com/wp-json/ </param>
             <param name="defaultPath"></param>
         </member>
-        <member name="M:WordPressPCL.Utility.HttpHelper.#ctor(System.Net.Http.HttpClient,System.String)">
+        <member name="M:WordPressPCL.Utility.HttpHelper.#ctor(System.Net.Http.HttpClient,System.String,System.Uri)">
             <summary>
             Constructor
             <paramref name="httpClient"/>
             </summary>
             <param name="httpClient">Http client which would be used for sending requests to the WordPress API endpoint.</param>
             <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
+            <param name="wordpressURI">(optional) Base WP REST API endpoint EX. http://demo.com/wp-json/. Use this if the BaseAddress of the httpClient is not set.</param>
         </member>
         <member name="T:WordPressPCL.Utility.MediaQueryBuilder">
             <summary>
@@ -4603,12 +4604,13 @@
             <param name="uri">URI for WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/"</param>
             <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
         </member>
-        <member name="M:WordPressPCL.WordPressClient.#ctor(System.Net.Http.HttpClient,System.String)">
+        <member name="M:WordPressPCL.WordPressClient.#ctor(System.Net.Http.HttpClient,System.String,System.Uri)">
             <summary>
             The WordPressClient holds all connection infos and provides methods to call WordPress APIs.
             </summary>
             <param name="httpClient">HttpClient with BaseAddress set which will be used for sending requests to the WordPress API endpoint.</param>
             <param name="defaultPath">Relative path to standard API endpoints, defaults to "wp/v2/"</param>
+            <param name="uri">URI for WordPress API endpoint, e.g. "http://demo.wp-api.org/wp-json/".  Use this if the BaseAddress of the httpClient is not set.</param>
         </member>
     </members>
 </doc>


### PR DESCRIPTION
According to [Microsoft recommendations](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use), HttpClient instances should be reused as much as possible. With that said, this PR is to support applications using a HttpClient instance that does not have a BaseAddress set, as it may be connecting to multiple different APIs.

I have implemented this as an optional parameter so that it's not a breaking change and users can continue to use it through the BaseAddress property of the HttpClient.

See [issue 312](https://github.com/wp-net/WordPressPCL/issues/312)