### PR TITLE
Prepare 3.0.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WordPressPCL
-![Integration Tests](https://github.com/wp-net/WordPressPCL/workflows/Integration%20Tests/badge.svg?branch=main) [![NuGet](https://img.shields.io/nuget/vpre/WordPressPCL)](https://www.nuget.org/packages/WordPressPCL/)
+![Integration Tests](https://github.com/wp-net/WordPressPCL/workflows/Integration%20Tests/badge.svg?branch=main) [![NuGet](https://img.shields.io/nuget/v/WordPressPCL)](https://www.nuget.org/packages/WordPressPCL/)
 
 This is a .NET 10 library for consuming the WordPress REST API in C# applications.
 If you find bugs or have any suggestions, feel free to create an issue.

--- a/docs/v3/breaking-changes.md
+++ b/docs/v3/breaking-changes.md
@@ -1,4 +1,4 @@
-# Breaking Changes in Version 2.x
+# Breaking Changes in Version 3.x
 
 - Separate sub client for Authentication accessed via `client.Auth`
 - Separate sub client for Settings accessed via `client.Settings`


### PR DESCRIPTION
This pull request makes minor documentation updates to clarify versioning and improve badge accuracy in the project.

- Documentation updates:
  * Updated the breaking changes documentation header in `docs/v3/breaking-changes.md` to correctly refer to version 3.x instead of 2.x.
  * Updated the NuGet badge in `README.md` to display the latest stable version instead of the prerelease version.