### PR TITLE
Expose WordPressClient.HttpHelper and add Base.CustomFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The project now uses GitHub Releases as the source of truth for versioned releas
 
 ## [Unreleased]
 
+### Added
+
+- `WordPressClient.HttpHelper` exposes the client's `HttpHelper`, so custom endpoints (custom post types, custom taxonomies) can be built on `CRUDOperation<TClass, QClass>` / `CustomRequest` while sharing the client's connection, authentication and serializer settings.
+- `Base.CustomFields` collects REST payload fields that are not mapped to a model property — those added by a plugin or a custom endpoint — on every model derived from `Base`. Backed by `[JsonExtensionData]`, so entries round-trip as top-level properties and an unset dictionary adds nothing to outgoing payloads.
+
 ### Changed
 
 - Placeholder for upcoming changes before the next GitHub release is published.

--- a/src/WordPressPCL/Models/Base.cs
+++ b/src/WordPressPCL/Models/Base.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 
@@ -18,4 +19,26 @@ public class Base
     [JsonPropertyName("id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int Id { get; set; }
+
+    /// <summary>
+    /// Fields of the REST payload that are not mapped to a property of this model, such as those
+    /// added by a plugin or by a custom endpoint.
+    /// </summary>
+    /// <remarks>
+    /// Backed by <see cref="JsonExtensionDataAttribute"/>: unrecognized properties are collected here
+    /// while deserializing, and each entry is written back as a top-level property while serializing.
+    /// The property stays <see langword="null"/> when a response carries no unmapped fields, and neither
+    /// a <see langword="null"/> nor an empty dictionary contributes anything to an outgoing payload.
+    /// <para>
+    /// Values are <see cref="System.Text.Json.JsonElement"/> instances after deserialization, while any
+    /// CLR object may be assigned before a request is sent. Entries are written verbatim, so a key that
+    /// collides with a mapped property name produces a duplicate JSON property.
+    /// </para>
+    /// <para>
+    /// System.Text.Json allows a single extension data member per type, so a derived model must not
+    /// declare one of its own.
+    /// </para>
+    /// </remarks>
+    [JsonExtensionData]
+    public IDictionary<string, object>? CustomFields { get; set; }
 }

--- a/src/WordPressPCL/WordPressClient.cs
+++ b/src/WordPressPCL/WordPressClient.cs
@@ -13,6 +13,17 @@ namespace WordPressPCL;
 public class WordPressClient : IDisposable
 {
     private readonly HttpHelper _httpHelper;
+
+    /// <summary>
+    /// Gets the <see cref="Utility.HttpHelper"/> instance used for sending requests to the WordPress API endpoint.
+    /// </summary>
+    /// <remarks>
+    /// Exposed so custom endpoints can share this client's connection, authentication and serializer settings,
+    /// for example by passing it to a <see cref="Client.CustomRequest"/> or to a custom
+    /// <see cref="CRUDOperation{TClass, QClass}"/> implementation for a custom post type or taxonomy.
+    /// </remarks>
+    public HttpHelper HttpHelper => _httpHelper;
+
     private const string DEFAULT_PATH = "wp/v2/";
 
     /// <summary>

--- a/src/WordPressPCL/WordPressPCL.xml
+++ b/src/WordPressPCL/WordPressPCL.xml
@@ -1210,6 +1210,27 @@
             Context: view, edit, embed
             </remarks>
         </member>
+        <member name="P:WordPressPCL.Models.Base.CustomFields">
+            <summary>
+            Fields of the REST payload that are not mapped to a property of this model, such as those
+            added by a plugin or by a custom endpoint.
+            </summary>
+            <remarks>
+            Backed by <see cref="T:System.Text.Json.Serialization.JsonExtensionDataAttribute"/>: unrecognized properties are collected here
+            while deserializing, and each entry is written back as a top-level property while serializing.
+            The property stays <see langword="null"/> when a response carries no unmapped fields, and neither
+            a <see langword="null"/> nor an empty dictionary contributes anything to an outgoing payload.
+            <para>
+            Values are <see cref="T:System.Text.Json.JsonElement"/> instances after deserialization, while any
+            CLR object may be assigned before a request is sent. Entries are written verbatim, so a key that
+            collides with a mapped property name produces a duplicate JSON property.
+            </para>
+            <para>
+            System.Text.Json allows a single extension data member per type, so a derived model must not
+            declare one of its own.
+            </para>
+            </remarks>
+        </member>
         <member name="T:WordPressPCL.Models.Category">
             <summary>
             Terms of the type category
@@ -4874,6 +4895,16 @@
             <summary>
             Main class containing the wrapper client with all public API endpoints.
             </summary>
+        </member>
+        <member name="P:WordPressPCL.WordPressClient.HttpHelper">
+            <summary>
+            Gets the <see cref="T:WordPressPCL.Utility.HttpHelper"/> instance used for sending requests to the WordPress API endpoint.
+            </summary>
+            <remarks>
+            Exposed so custom endpoints can share this client's connection, authentication and serializer settings,
+            for example by passing it to a <see cref="T:WordPressPCL.Client.CustomRequest"/> or to a custom
+            <see cref="T:WordPressPCL.Client.CRUDOperation`2"/> implementation for a custom post type or taxonomy.
+            </remarks>
         </member>
         <member name="P:WordPressPCL.WordPressClient.WordPressUri">
             <summary>

--- a/tests/WordPressPCL.Tests.Selfhosted/Models/BaseCustomFields_Tests.cs
+++ b/tests/WordPressPCL.Tests.Selfhosted/Models/BaseCustomFields_Tests.cs
@@ -1,0 +1,102 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Text.Json;
+using WordPressPCL.Models;
+
+namespace WordPressPCL.Tests.Selfhosted.Models;
+
+[TestClass]
+public class BaseCustomFields_Tests
+{
+    private const string PostWithUnmappedFields = """
+    {
+        "id": 7,
+        "slug": "a-post",
+        "checksum": "123",
+        "gallery": [1, 2, 3],
+        "_links": { "self": [{ "href": "https://example.org/wp-json/wp/v2/posts/7" }] }
+    }
+    """;
+
+    [TestMethod]
+    public void CustomFields_CollectsUnmappedProperties()
+    {
+        Post? post = JsonSerializer.Deserialize<Post>(PostWithUnmappedFields);
+
+        Assert.IsNotNull(post);
+        Assert.AreEqual(7, post.Id);
+        Assert.AreEqual("a-post", post.Slug);
+        Assert.IsNotNull(post.CustomFields);
+        CollectionAssert.AreEquivalent(new[] { "checksum", "gallery" }, new List<string>(post.CustomFields.Keys));
+    }
+
+    [TestMethod]
+    public void CustomFields_LeavesMappedPropertiesAlone()
+    {
+        Post? post = JsonSerializer.Deserialize<Post>(PostWithUnmappedFields);
+
+        Assert.IsNotNull(post);
+        Assert.IsNotNull(post.Links);
+        Assert.IsNotNull(post.CustomFields);
+        Assert.IsFalse(post.CustomFields.ContainsKey("_links"));
+        Assert.IsFalse(post.CustomFields.ContainsKey("id"));
+        Assert.IsFalse(post.CustomFields.ContainsKey("slug"));
+    }
+
+    [TestMethod]
+    public void CustomFields_IsNullWhenEverythingIsMapped()
+    {
+        Post? post = JsonSerializer.Deserialize<Post>("""{"id":7,"slug":"a-post"}""");
+
+        Assert.IsNotNull(post);
+        Assert.IsNull(post.CustomFields);
+    }
+
+    [TestMethod]
+    public void CustomFields_AreWrittenAsTopLevelProperties()
+    {
+        Post post = new()
+        {
+            Slug = "a-post",
+            CustomFields = new Dictionary<string, object>
+            {
+                ["checksum"] = "123",
+                ["gallery"] = new[] { 1, 2, 3 },
+            },
+        };
+
+        string json = JsonSerializer.Serialize(post);
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+        Assert.AreEqual("123", root.GetProperty("checksum").GetString());
+        Assert.AreEqual(3, root.GetProperty("gallery").GetArrayLength());
+        Assert.IsFalse(root.TryGetProperty("custom_fields", out _), "Entries must not be nested under a wrapper property.");
+    }
+
+    [TestMethod]
+    public void CustomFields_AddNothingToPayloadWhenUnset()
+    {
+        string fromNull = JsonSerializer.Serialize(new Post { Slug = "a-post" });
+        string fromEmpty = JsonSerializer.Serialize(new Post
+        {
+            Slug = "a-post",
+            CustomFields = new Dictionary<string, object>(),
+        });
+
+        Assert.AreEqual(fromNull, fromEmpty);
+    }
+
+    [TestMethod]
+    public void CustomFields_SurviveARoundTrip()
+    {
+        Post? post = JsonSerializer.Deserialize<Post>(PostWithUnmappedFields);
+        Assert.IsNotNull(post);
+
+        Post? roundTripped = JsonSerializer.Deserialize<Post>(JsonSerializer.Serialize(post));
+
+        Assert.IsNotNull(roundTripped);
+        Assert.IsNotNull(roundTripped.CustomFields);
+        Assert.AreEqual("123", ((JsonElement)roundTripped.CustomFields["checksum"]).GetString());
+    }
+}


### PR DESCRIPTION
Expose WordPressClient.HttpHelper and add Base.CustomFields

**Added  `WordPressClient.HttpHelper`**

`CRUDOperation<TClass, QClass>` is `public abstract` with a `protected` constructor taking an `HttpHelper`, and `CustomRequest` accepts one as well, so the library is clearly designed to let consumers add custom post types and taxonomies. But `WordPressClient` held its `HttpHelper` in a private field with no accessor, leaving no supported way to obtain one.

The only workaround was constructing a second `HttpHelper`, which brings its own `HttpClient` and its own authentication state. Instead of this complexity, this adds a read-only property returning the existing instance:

    var taxonomy = new MyCustomTaxonomy(client.HttpHelper, "my-taxonomy");

**Added `Base.CustomFields`**

WordPress responses routinely carry fields the models do not map — added by plugins, by `register_rest_field`, or by custom endpoints. They were silently discarded during deserialization, with no way to read them short of declaring a derived model per
entity type.

This adds a `[JsonExtensionData]` member on `Base`, so unmapped fields are available on `Post`, `Page`, `Comment`, `User`, `Term`, `MediaItem` and `PostRevision`, and can be written back on create and update.

### Tests

- Added unit tests covering CustomFields.
- The self-hosted integration suite passes in full against a dockerized WordPress.

